### PR TITLE
feat(codec): add bidirectional codec module

### DIFF
--- a/src/msgpack_gleam/codec.gleam
+++ b/src/msgpack_gleam/codec.gleam
@@ -1,0 +1,1035 @@
+/// Bidirectional codecs for MessagePack serialization.
+///
+/// Codecs combine encoding and decoding into a single definition,
+/// eliminating the need to write separate encoder and decoder functions.
+///
+/// ## Example
+///
+/// ```gleam
+/// import msgpack_gleam/codec.{type Codec}
+///
+/// pub type Person {
+///   Person(name: String, age: Int)
+/// }
+///
+/// pub fn person_codec() -> Codec(Person) {
+///   codec.object2(
+///     Person,
+///     codec.field("name", codec.string(), fn(p) { p.name }),
+///     codec.field("age", codec.int(), fn(p) { p.age }),
+///   )
+/// }
+/// ```
+import gleam/dict.{type Dict}
+import gleam/int
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/result
+import gleam/string
+import msgpack_gleam/value.{type Value}
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/// A bidirectional codec that can both encode and decode values of type `a`.
+pub type Codec(a) {
+  Codec(encoder: fn(a) -> Value, decoder: fn(Value) -> Result(a, DecodeError))
+}
+
+/// Errors that can occur during decoding.
+pub type DecodeError {
+  /// Expected a different type
+  TypeMismatch(expected: String, got: String)
+  /// Missing required field in map
+  MissingField(field: String)
+  /// Field exists but failed to decode
+  FieldError(field: String, inner: DecodeError)
+  /// Array element failed to decode
+  IndexError(index: Int, inner: DecodeError)
+  /// Extension type code mismatch
+  ExtensionTypeMismatch(expected: Int, got: Int)
+  /// Value out of expected range
+  OutOfRange(message: String)
+  /// Custom error message
+  CustomError(message: String)
+  /// Multiple errors collected
+  AllFailed(errors: List(DecodeError))
+}
+
+/// A field definition for object codecs.
+/// Contains the field name, its codec, and an accessor function.
+pub type Field(record, field_type) {
+  Field(
+    name: String,
+    codec: Codec(field_type),
+    accessor: fn(record) -> field_type,
+  )
+}
+
+// ============================================================================
+// Core Functions
+// ============================================================================
+
+/// Encode a value using a codec.
+pub fn encode(codec: Codec(a), val: a) -> Value {
+  codec.encoder(val)
+}
+
+/// Decode a value using a codec.
+pub fn decode(codec: Codec(a), val: Value) -> Result(a, DecodeError) {
+  codec.decoder(val)
+}
+
+/// Create a custom codec from encoder and decoder functions.
+pub fn custom(
+  encoder: fn(a) -> Value,
+  decoder: fn(Value) -> Result(a, DecodeError),
+) -> Codec(a) {
+  Codec(encoder:, decoder:)
+}
+
+// ============================================================================
+// Primitive Codecs
+// ============================================================================
+
+/// Codec for boolean values.
+pub fn bool() -> Codec(Bool) {
+  Codec(encoder: fn(b) { value.Boolean(b) }, decoder: fn(v) {
+    case v {
+      value.Boolean(b) -> Ok(b)
+      other -> Error(TypeMismatch("Boolean", value_type_name(other)))
+    }
+  })
+}
+
+/// Codec for integer values.
+pub fn int() -> Codec(Int) {
+  Codec(encoder: fn(i) { value.Integer(i) }, decoder: fn(v) {
+    case v {
+      value.Integer(i) -> Ok(i)
+      other -> Error(TypeMismatch("Integer", value_type_name(other)))
+    }
+  })
+}
+
+/// Codec for float values.
+/// When decoding, integers are automatically coerced to floats.
+pub fn float() -> Codec(Float) {
+  Codec(encoder: fn(f) { value.Float(f) }, decoder: fn(v) {
+    case v {
+      value.Float(f) -> Ok(f)
+      value.Integer(i) -> Ok(int.to_float(i))
+      other -> Error(TypeMismatch("Float", value_type_name(other)))
+    }
+  })
+}
+
+/// Codec for float values with strict type checking.
+/// Integers are NOT coerced to floats.
+pub fn float_strict() -> Codec(Float) {
+  Codec(encoder: fn(f) { value.Float(f) }, decoder: fn(v) {
+    case v {
+      value.Float(f) -> Ok(f)
+      other -> Error(TypeMismatch("Float", value_type_name(other)))
+    }
+  })
+}
+
+/// Codec for string values.
+pub fn string() -> Codec(String) {
+  Codec(encoder: fn(s) { value.String(s) }, decoder: fn(v) {
+    case v {
+      value.String(s) -> Ok(s)
+      other -> Error(TypeMismatch("String", value_type_name(other)))
+    }
+  })
+}
+
+/// Codec for binary data.
+pub fn binary() -> Codec(BitArray) {
+  Codec(encoder: fn(b) { value.Binary(b) }, decoder: fn(v) {
+    case v {
+      value.Binary(b) -> Ok(b)
+      other -> Error(TypeMismatch("Binary", value_type_name(other)))
+    }
+  })
+}
+
+/// Codec for raw MessagePack values (identity codec).
+/// Useful when you want to preserve values without interpretation.
+pub fn raw_value() -> Codec(Value) {
+  Codec(encoder: fn(v) { v }, decoder: fn(v) { Ok(v) })
+}
+
+// ============================================================================
+// Composite Codecs
+// ============================================================================
+
+/// Codec for optional values.
+/// Encodes `None` as MessagePack Nil, `Some(x)` using the inner codec.
+pub fn nullable(inner: Codec(a)) -> Codec(Option(a)) {
+  Codec(
+    encoder: fn(opt) {
+      case opt {
+        Some(a) -> inner.encoder(a)
+        None -> value.Nil
+      }
+    },
+    decoder: fn(v) {
+      case v {
+        value.Nil -> Ok(None)
+        other ->
+          case inner.decoder(other) {
+            Ok(a) -> Ok(Some(a))
+            Error(e) -> Error(e)
+          }
+      }
+    },
+  )
+}
+
+/// Codec for lists/arrays.
+pub fn list(item: Codec(a)) -> Codec(List(a)) {
+  Codec(
+    encoder: fn(items) { value.Array(list.map(items, item.encoder)) },
+    decoder: fn(v) {
+      case v {
+        value.Array(items) -> decode_list_items(items, item.decoder, 0, [])
+        other -> Error(TypeMismatch("Array", value_type_name(other)))
+      }
+    },
+  )
+}
+
+fn decode_list_items(
+  items: List(Value),
+  decoder: fn(Value) -> Result(a, DecodeError),
+  index: Int,
+  acc: List(a),
+) -> Result(List(a), DecodeError) {
+  case items {
+    [] -> Ok(list.reverse(acc))
+    [head, ..tail] ->
+      case decoder(head) {
+        Ok(decoded) ->
+          decode_list_items(tail, decoder, index + 1, [decoded, ..acc])
+        Error(e) -> Error(IndexError(index, e))
+      }
+  }
+}
+
+/// Codec for dictionaries with string keys.
+pub fn string_dict(value_codec: Codec(v)) -> Codec(Dict(String, v)) {
+  Codec(
+    encoder: fn(d) {
+      value.Map(
+        dict.to_list(d)
+        |> list.map(fn(pair) {
+          #(value.String(pair.0), value_codec.encoder(pair.1))
+        }),
+      )
+    },
+    decoder: fn(v) {
+      case v {
+        value.Map(pairs) ->
+          decode_string_dict_pairs(pairs, value_codec.decoder, dict.new())
+        other -> Error(TypeMismatch("Map", value_type_name(other)))
+      }
+    },
+  )
+}
+
+fn decode_string_dict_pairs(
+  pairs: List(#(Value, Value)),
+  value_decoder: fn(Value) -> Result(v, DecodeError),
+  acc: Dict(String, v),
+) -> Result(Dict(String, v), DecodeError) {
+  case pairs {
+    [] -> Ok(acc)
+    [#(key, val), ..rest] ->
+      case key {
+        value.String(k) ->
+          case value_decoder(val) {
+            Ok(decoded) ->
+              decode_string_dict_pairs(
+                rest,
+                value_decoder,
+                dict.insert(acc, k, decoded),
+              )
+            Error(e) -> Error(FieldError(k, e))
+          }
+        other -> Error(TypeMismatch("String key", value_type_name(other)))
+      }
+  }
+}
+
+/// Codec for dictionaries with arbitrary key types.
+pub fn dict(key_codec: Codec(k), value_codec: Codec(v)) -> Codec(Dict(k, v)) {
+  Codec(
+    encoder: fn(d) {
+      value.Map(
+        dict.to_list(d)
+        |> list.map(fn(pair) {
+          #(key_codec.encoder(pair.0), value_codec.encoder(pair.1))
+        }),
+      )
+    },
+    decoder: fn(v) {
+      case v {
+        value.Map(pairs) ->
+          decode_dict_pairs(
+            pairs,
+            key_codec.decoder,
+            value_codec.decoder,
+            dict.new(),
+          )
+        other -> Error(TypeMismatch("Map", value_type_name(other)))
+      }
+    },
+  )
+}
+
+fn decode_dict_pairs(
+  pairs: List(#(Value, Value)),
+  key_decoder: fn(Value) -> Result(k, DecodeError),
+  value_decoder: fn(Value) -> Result(v, DecodeError),
+  acc: Dict(k, v),
+) -> Result(Dict(k, v), DecodeError) {
+  case pairs {
+    [] -> Ok(acc)
+    [#(key, val), ..rest] ->
+      case key_decoder(key), value_decoder(val) {
+        Ok(k), Ok(v) ->
+          decode_dict_pairs(
+            rest,
+            key_decoder,
+            value_decoder,
+            dict.insert(acc, k, v),
+          )
+        Error(e), _ ->
+          Error(CustomError("Failed to decode map key: " <> format_error(e)))
+        _, Error(e) ->
+          Error(CustomError("Failed to decode map value: " <> format_error(e)))
+      }
+  }
+}
+
+/// Codec for MessagePack extension types.
+pub fn extension(type_code: Int) -> Codec(BitArray) {
+  Codec(encoder: fn(data) { value.Extension(type_code, data) }, decoder: fn(v) {
+    case v {
+      value.Extension(tc, data) if tc == type_code -> Ok(data)
+      value.Extension(tc, _) -> Error(ExtensionTypeMismatch(type_code, tc))
+      other -> Error(TypeMismatch("Extension", value_type_name(other)))
+    }
+  })
+}
+
+/// Codec for any extension type (returns type code and data).
+pub fn any_extension() -> Codec(#(Int, BitArray)) {
+  Codec(
+    encoder: fn(pair: #(Int, BitArray)) { value.Extension(pair.0, pair.1) },
+    decoder: fn(v) {
+      case v {
+        value.Extension(tc, data) -> Ok(#(tc, data))
+        other -> Error(TypeMismatch("Extension", value_type_name(other)))
+      }
+    },
+  )
+}
+
+// ============================================================================
+// Field Helper
+// ============================================================================
+
+/// Create a field definition for use with object codecs.
+pub fn field(
+  name: String,
+  codec: Codec(field_type),
+  accessor: fn(record) -> field_type,
+) -> Field(record, field_type) {
+  Field(name:, codec:, accessor:)
+}
+
+// ============================================================================
+// Object Codecs (Record Builders)
+// ============================================================================
+
+/// Codec for objects with 1 field.
+pub fn object1(
+  constructor: fn(a) -> record,
+  field1: Field(record, a),
+) -> Codec(record) {
+  Codec(
+    encoder: fn(record) {
+      value.Map([
+        #(
+          value.String(field1.name),
+          field1.codec.encoder(field1.accessor(record)),
+        ),
+      ])
+    },
+    decoder: fn(v) {
+      use a <- result.try(decode_field(v, field1))
+      Ok(constructor(a))
+    },
+  )
+}
+
+/// Codec for objects with 2 fields.
+pub fn object2(
+  constructor: fn(a, b) -> record,
+  field1: Field(record, a),
+  field2: Field(record, b),
+) -> Codec(record) {
+  Codec(
+    encoder: fn(record) {
+      value.Map([
+        #(
+          value.String(field1.name),
+          field1.codec.encoder(field1.accessor(record)),
+        ),
+        #(
+          value.String(field2.name),
+          field2.codec.encoder(field2.accessor(record)),
+        ),
+      ])
+    },
+    decoder: fn(v) {
+      use a <- result.try(decode_field(v, field1))
+      use b <- result.try(decode_field(v, field2))
+      Ok(constructor(a, b))
+    },
+  )
+}
+
+/// Codec for objects with 3 fields.
+pub fn object3(
+  constructor: fn(a, b, c) -> record,
+  field1: Field(record, a),
+  field2: Field(record, b),
+  field3: Field(record, c),
+) -> Codec(record) {
+  Codec(
+    encoder: fn(record) {
+      value.Map([
+        #(
+          value.String(field1.name),
+          field1.codec.encoder(field1.accessor(record)),
+        ),
+        #(
+          value.String(field2.name),
+          field2.codec.encoder(field2.accessor(record)),
+        ),
+        #(
+          value.String(field3.name),
+          field3.codec.encoder(field3.accessor(record)),
+        ),
+      ])
+    },
+    decoder: fn(v) {
+      use a <- result.try(decode_field(v, field1))
+      use b <- result.try(decode_field(v, field2))
+      use c <- result.try(decode_field(v, field3))
+      Ok(constructor(a, b, c))
+    },
+  )
+}
+
+/// Codec for objects with 4 fields.
+pub fn object4(
+  constructor: fn(a, b, c, d) -> record,
+  field1: Field(record, a),
+  field2: Field(record, b),
+  field3: Field(record, c),
+  field4: Field(record, d),
+) -> Codec(record) {
+  Codec(
+    encoder: fn(record) {
+      value.Map([
+        #(
+          value.String(field1.name),
+          field1.codec.encoder(field1.accessor(record)),
+        ),
+        #(
+          value.String(field2.name),
+          field2.codec.encoder(field2.accessor(record)),
+        ),
+        #(
+          value.String(field3.name),
+          field3.codec.encoder(field3.accessor(record)),
+        ),
+        #(
+          value.String(field4.name),
+          field4.codec.encoder(field4.accessor(record)),
+        ),
+      ])
+    },
+    decoder: fn(v) {
+      use a <- result.try(decode_field(v, field1))
+      use b <- result.try(decode_field(v, field2))
+      use c <- result.try(decode_field(v, field3))
+      use d <- result.try(decode_field(v, field4))
+      Ok(constructor(a, b, c, d))
+    },
+  )
+}
+
+/// Codec for objects with 5 fields.
+pub fn object5(
+  constructor: fn(a, b, c, d, e) -> record,
+  field1: Field(record, a),
+  field2: Field(record, b),
+  field3: Field(record, c),
+  field4: Field(record, d),
+  field5: Field(record, e),
+) -> Codec(record) {
+  Codec(
+    encoder: fn(record) {
+      value.Map([
+        #(
+          value.String(field1.name),
+          field1.codec.encoder(field1.accessor(record)),
+        ),
+        #(
+          value.String(field2.name),
+          field2.codec.encoder(field2.accessor(record)),
+        ),
+        #(
+          value.String(field3.name),
+          field3.codec.encoder(field3.accessor(record)),
+        ),
+        #(
+          value.String(field4.name),
+          field4.codec.encoder(field4.accessor(record)),
+        ),
+        #(
+          value.String(field5.name),
+          field5.codec.encoder(field5.accessor(record)),
+        ),
+      ])
+    },
+    decoder: fn(v) {
+      use a <- result.try(decode_field(v, field1))
+      use b <- result.try(decode_field(v, field2))
+      use c <- result.try(decode_field(v, field3))
+      use d <- result.try(decode_field(v, field4))
+      use e <- result.try(decode_field(v, field5))
+      Ok(constructor(a, b, c, d, e))
+    },
+  )
+}
+
+/// Codec for objects with 6 fields.
+pub fn object6(
+  constructor: fn(a, b, c, d, e, f) -> record,
+  field1: Field(record, a),
+  field2: Field(record, b),
+  field3: Field(record, c),
+  field4: Field(record, d),
+  field5: Field(record, e),
+  field6: Field(record, f),
+) -> Codec(record) {
+  Codec(
+    encoder: fn(record) {
+      value.Map([
+        #(
+          value.String(field1.name),
+          field1.codec.encoder(field1.accessor(record)),
+        ),
+        #(
+          value.String(field2.name),
+          field2.codec.encoder(field2.accessor(record)),
+        ),
+        #(
+          value.String(field3.name),
+          field3.codec.encoder(field3.accessor(record)),
+        ),
+        #(
+          value.String(field4.name),
+          field4.codec.encoder(field4.accessor(record)),
+        ),
+        #(
+          value.String(field5.name),
+          field5.codec.encoder(field5.accessor(record)),
+        ),
+        #(
+          value.String(field6.name),
+          field6.codec.encoder(field6.accessor(record)),
+        ),
+      ])
+    },
+    decoder: fn(v) {
+      use a <- result.try(decode_field(v, field1))
+      use b <- result.try(decode_field(v, field2))
+      use c <- result.try(decode_field(v, field3))
+      use d <- result.try(decode_field(v, field4))
+      use e <- result.try(decode_field(v, field5))
+      use f <- result.try(decode_field(v, field6))
+      Ok(constructor(a, b, c, d, e, f))
+    },
+  )
+}
+
+/// Codec for objects with 7 fields.
+pub fn object7(
+  constructor: fn(a, b, c, d, e, f, g) -> record,
+  field1: Field(record, a),
+  field2: Field(record, b),
+  field3: Field(record, c),
+  field4: Field(record, d),
+  field5: Field(record, e),
+  field6: Field(record, f),
+  field7: Field(record, g),
+) -> Codec(record) {
+  Codec(
+    encoder: fn(record) {
+      value.Map([
+        #(
+          value.String(field1.name),
+          field1.codec.encoder(field1.accessor(record)),
+        ),
+        #(
+          value.String(field2.name),
+          field2.codec.encoder(field2.accessor(record)),
+        ),
+        #(
+          value.String(field3.name),
+          field3.codec.encoder(field3.accessor(record)),
+        ),
+        #(
+          value.String(field4.name),
+          field4.codec.encoder(field4.accessor(record)),
+        ),
+        #(
+          value.String(field5.name),
+          field5.codec.encoder(field5.accessor(record)),
+        ),
+        #(
+          value.String(field6.name),
+          field6.codec.encoder(field6.accessor(record)),
+        ),
+        #(
+          value.String(field7.name),
+          field7.codec.encoder(field7.accessor(record)),
+        ),
+      ])
+    },
+    decoder: fn(v) {
+      use a <- result.try(decode_field(v, field1))
+      use b <- result.try(decode_field(v, field2))
+      use c <- result.try(decode_field(v, field3))
+      use d <- result.try(decode_field(v, field4))
+      use e <- result.try(decode_field(v, field5))
+      use f <- result.try(decode_field(v, field6))
+      use g <- result.try(decode_field(v, field7))
+      Ok(constructor(a, b, c, d, e, f, g))
+    },
+  )
+}
+
+/// Codec for objects with 8 fields.
+pub fn object8(
+  constructor: fn(a, b, c, d, e, f, g, h) -> record,
+  field1: Field(record, a),
+  field2: Field(record, b),
+  field3: Field(record, c),
+  field4: Field(record, d),
+  field5: Field(record, e),
+  field6: Field(record, f),
+  field7: Field(record, g),
+  field8: Field(record, h),
+) -> Codec(record) {
+  Codec(
+    encoder: fn(record) {
+      value.Map([
+        #(
+          value.String(field1.name),
+          field1.codec.encoder(field1.accessor(record)),
+        ),
+        #(
+          value.String(field2.name),
+          field2.codec.encoder(field2.accessor(record)),
+        ),
+        #(
+          value.String(field3.name),
+          field3.codec.encoder(field3.accessor(record)),
+        ),
+        #(
+          value.String(field4.name),
+          field4.codec.encoder(field4.accessor(record)),
+        ),
+        #(
+          value.String(field5.name),
+          field5.codec.encoder(field5.accessor(record)),
+        ),
+        #(
+          value.String(field6.name),
+          field6.codec.encoder(field6.accessor(record)),
+        ),
+        #(
+          value.String(field7.name),
+          field7.codec.encoder(field7.accessor(record)),
+        ),
+        #(
+          value.String(field8.name),
+          field8.codec.encoder(field8.accessor(record)),
+        ),
+      ])
+    },
+    decoder: fn(v) {
+      use a <- result.try(decode_field(v, field1))
+      use b <- result.try(decode_field(v, field2))
+      use c <- result.try(decode_field(v, field3))
+      use d <- result.try(decode_field(v, field4))
+      use e <- result.try(decode_field(v, field5))
+      use f <- result.try(decode_field(v, field6))
+      use g <- result.try(decode_field(v, field7))
+      use h <- result.try(decode_field(v, field8))
+      Ok(constructor(a, b, c, d, e, f, g, h))
+    },
+  )
+}
+
+// ============================================================================
+// Codec Combinators
+// ============================================================================
+
+/// Transform a codec's values using bidirectional mapping functions.
+pub fn map(
+  codec: Codec(a),
+  encode_map: fn(b) -> a,
+  decode_map: fn(a) -> b,
+) -> Codec(b) {
+  Codec(encoder: fn(b) { codec.encoder(encode_map(b)) }, decoder: fn(v) {
+    result.map(codec.decoder(v), decode_map)
+  })
+}
+
+/// Transform a codec with a fallible decode mapping.
+pub fn try_map(
+  codec: Codec(a),
+  encode_map: fn(b) -> a,
+  decode_map: fn(a) -> Result(b, DecodeError),
+) -> Codec(b) {
+  Codec(encoder: fn(b) { codec.encoder(encode_map(b)) }, decoder: fn(v) {
+    result.try(codec.decoder(v), decode_map)
+  })
+}
+
+/// Try multiple codecs in order, using the first that succeeds for decoding.
+/// Encoding uses the first codec.
+pub fn one_of(codecs: List(Codec(a))) -> Codec(a) {
+  case codecs {
+    [] ->
+      Codec(encoder: fn(_) { value.Nil }, decoder: fn(_) {
+        Error(CustomError("No codecs provided to one_of"))
+      })
+    [first, ..rest] ->
+      Codec(encoder: first.encoder, decoder: fn(v) {
+        try_codecs(v, [first, ..rest], [])
+      })
+  }
+}
+
+fn try_codecs(
+  v: Value,
+  codecs: List(Codec(a)),
+  errors: List(DecodeError),
+) -> Result(a, DecodeError) {
+  case codecs {
+    [] -> Error(AllFailed(list.reverse(errors)))
+    [codec, ..rest] ->
+      case codec.decoder(v) {
+        Ok(a) -> Ok(a)
+        Error(e) -> try_codecs(v, rest, [e, ..errors])
+      }
+  }
+}
+
+/// Create a codec that always succeeds with a constant value when decoding.
+/// Useful for default values or variant tags.
+pub fn succeed(val: a) -> Codec(a) {
+  Codec(encoder: fn(_) { value.Nil }, decoder: fn(_) { Ok(val) })
+}
+
+/// Create a codec that always fails with the given error.
+pub fn fail(error: String) -> Codec(a) {
+  Codec(encoder: fn(_) { value.Nil }, decoder: fn(_) {
+    Error(CustomError(error))
+  })
+}
+
+/// Add a default value for when decoding fails.
+pub fn with_default(codec: Codec(a), default: a) -> Codec(a) {
+  Codec(encoder: codec.encoder, decoder: fn(v) {
+    case codec.decoder(v) {
+      Ok(a) -> Ok(a)
+      Error(_) -> Ok(default)
+    }
+  })
+}
+
+/// Lazy codec evaluation for recursive types.
+pub fn lazy(make_codec: fn() -> Codec(a)) -> Codec(a) {
+  Codec(encoder: fn(a) { make_codec().encoder(a) }, decoder: fn(v) {
+    make_codec().decoder(v)
+  })
+}
+
+// ============================================================================
+// Tuple Codecs
+// ============================================================================
+
+/// Codec for 2-tuples encoded as arrays.
+pub fn tuple2(codec1: Codec(a), codec2: Codec(b)) -> Codec(#(a, b)) {
+  Codec(
+    encoder: fn(t: #(a, b)) {
+      value.Array([codec1.encoder(t.0), codec2.encoder(t.1)])
+    },
+    decoder: fn(v) {
+      case v {
+        value.Array([v1, v2]) -> {
+          use a <- result.try(map_index_error(codec1.decoder(v1), 0))
+          use b <- result.try(map_index_error(codec2.decoder(v2), 1))
+          Ok(#(a, b))
+        }
+        value.Array(items) ->
+          Error(CustomError(
+            "Expected array of 2 elements, got "
+            <> int.to_string(list.length(items)),
+          ))
+        other -> Error(TypeMismatch("Array", value_type_name(other)))
+      }
+    },
+  )
+}
+
+/// Codec for 3-tuples encoded as arrays.
+pub fn tuple3(
+  codec1: Codec(a),
+  codec2: Codec(b),
+  codec3: Codec(c),
+) -> Codec(#(a, b, c)) {
+  Codec(
+    encoder: fn(t: #(a, b, c)) {
+      value.Array([
+        codec1.encoder(t.0),
+        codec2.encoder(t.1),
+        codec3.encoder(t.2),
+      ])
+    },
+    decoder: fn(v) {
+      case v {
+        value.Array([v1, v2, v3]) -> {
+          use a <- result.try(map_index_error(codec1.decoder(v1), 0))
+          use b <- result.try(map_index_error(codec2.decoder(v2), 1))
+          use c <- result.try(map_index_error(codec3.decoder(v3), 2))
+          Ok(#(a, b, c))
+        }
+        value.Array(items) ->
+          Error(CustomError(
+            "Expected array of 3 elements, got "
+            <> int.to_string(list.length(items)),
+          ))
+        other -> Error(TypeMismatch("Array", value_type_name(other)))
+      }
+    },
+  )
+}
+
+/// Codec for 4-tuples encoded as arrays.
+pub fn tuple4(
+  codec1: Codec(a),
+  codec2: Codec(b),
+  codec3: Codec(c),
+  codec4: Codec(d),
+) -> Codec(#(a, b, c, d)) {
+  Codec(
+    encoder: fn(t: #(a, b, c, d)) {
+      value.Array([
+        codec1.encoder(t.0),
+        codec2.encoder(t.1),
+        codec3.encoder(t.2),
+        codec4.encoder(t.3),
+      ])
+    },
+    decoder: fn(v) {
+      case v {
+        value.Array([v1, v2, v3, v4]) -> {
+          use a <- result.try(map_index_error(codec1.decoder(v1), 0))
+          use b <- result.try(map_index_error(codec2.decoder(v2), 1))
+          use c <- result.try(map_index_error(codec3.decoder(v3), 2))
+          use d <- result.try(map_index_error(codec4.decoder(v4), 3))
+          Ok(#(a, b, c, d))
+        }
+        value.Array(items) ->
+          Error(CustomError(
+            "Expected array of 4 elements, got "
+            <> int.to_string(list.length(items)),
+          ))
+        other -> Error(TypeMismatch("Array", value_type_name(other)))
+      }
+    },
+  )
+}
+
+// ============================================================================
+// Constrained Codecs
+// ============================================================================
+
+/// Codec for integers within a specific range.
+pub fn int_range(min: Int, max: Int) -> Codec(Int) {
+  Codec(encoder: fn(i) { value.Integer(i) }, decoder: fn(v) {
+    case v {
+      value.Integer(i) if i >= min && i <= max -> Ok(i)
+      value.Integer(i) ->
+        Error(OutOfRange(
+          "Integer "
+          <> int.to_string(i)
+          <> " not in range ["
+          <> int.to_string(min)
+          <> ", "
+          <> int.to_string(max)
+          <> "]",
+        ))
+      other -> Error(TypeMismatch("Integer", value_type_name(other)))
+    }
+  })
+}
+
+/// Codec for non-empty strings.
+pub fn non_empty_string() -> Codec(String) {
+  Codec(encoder: fn(s) { value.String(s) }, decoder: fn(v) {
+    case v {
+      value.String(s) if s != "" -> Ok(s)
+      value.String(_) -> Error(OutOfRange("String must not be empty"))
+      other -> Error(TypeMismatch("String", value_type_name(other)))
+    }
+  })
+}
+
+/// Codec for non-empty lists.
+pub fn non_empty_list(item: Codec(a)) -> Codec(List(a)) {
+  Codec(
+    encoder: fn(items) { value.Array(list.map(items, item.encoder)) },
+    decoder: fn(v) {
+      case v {
+        value.Array([]) -> Error(OutOfRange("List must not be empty"))
+        value.Array(items) -> decode_list_items(items, item.decoder, 0, [])
+        other -> Error(TypeMismatch("Array", value_type_name(other)))
+      }
+    },
+  )
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+fn decode_field(v: Value, field_def: Field(record, a)) -> Result(a, DecodeError) {
+  case v {
+    value.Map(pairs) ->
+      case find_field_in_pairs(pairs, field_def.name) {
+        Ok(field_value) ->
+          case field_def.codec.decoder(field_value) {
+            Ok(a) -> Ok(a)
+            Error(e) -> Error(FieldError(field_def.name, e))
+          }
+        Error(_) -> Error(MissingField(field_def.name))
+      }
+    other -> Error(TypeMismatch("Map", value_type_name(other)))
+  }
+}
+
+fn find_field_in_pairs(
+  pairs: List(#(Value, Value)),
+  name: String,
+) -> Result(Value, DecodeError) {
+  case pairs {
+    [] -> Error(MissingField(name))
+    [#(value.String(key), val), ..rest] ->
+      case key == name {
+        True -> Ok(val)
+        False -> find_field_in_pairs(rest, name)
+      }
+    [_, ..rest] -> find_field_in_pairs(rest, name)
+  }
+}
+
+fn map_index_error(
+  res: Result(a, DecodeError),
+  index: Int,
+) -> Result(a, DecodeError) {
+  case res {
+    Ok(a) -> Ok(a)
+    Error(e) -> Error(IndexError(index, e))
+  }
+}
+
+fn value_type_name(v: Value) -> String {
+  case v {
+    value.Nil -> "Nil"
+    value.Boolean(_) -> "Boolean"
+    value.Integer(_) -> "Integer"
+    value.Float(_) -> "Float"
+    value.String(_) -> "String"
+    value.Binary(_) -> "Binary"
+    value.Array(_) -> "Array"
+    value.Map(_) -> "Map"
+    value.Extension(_, _) -> "Extension"
+  }
+}
+
+// ============================================================================
+// Error Formatting
+// ============================================================================
+
+/// Format a decode error as a human-readable string.
+pub fn format_error(error: DecodeError) -> String {
+  format_error_inner(error, "")
+}
+
+fn format_error_inner(error: DecodeError, path: String) -> String {
+  case error {
+    TypeMismatch(expected, got) ->
+      path_prefix(path) <> "expected " <> expected <> ", got " <> got
+    MissingField(name) ->
+      path_prefix(path) <> "missing field \"" <> name <> "\""
+    FieldError(name, inner) ->
+      format_error_inner(inner, append_path(path, "." <> name))
+    IndexError(index, inner) ->
+      format_error_inner(
+        inner,
+        append_path(path, "[" <> int.to_string(index) <> "]"),
+      )
+    ExtensionTypeMismatch(expected, got) ->
+      path_prefix(path)
+      <> "expected extension type "
+      <> int.to_string(expected)
+      <> ", got "
+      <> int.to_string(got)
+    OutOfRange(message) -> path_prefix(path) <> message
+    CustomError(message) -> path_prefix(path) <> message
+    AllFailed(errors) ->
+      path_prefix(path)
+      <> "all alternatives failed: ["
+      <> string.join(list.map(errors, format_error), ", ")
+      <> "]"
+  }
+}
+
+fn path_prefix(path: String) -> String {
+  case path {
+    "" -> ""
+    p -> "at " <> p <> ": "
+  }
+}
+
+fn append_path(base: String, suffix: String) -> String {
+  case base {
+    "" -> "$" <> suffix
+    p -> p <> suffix
+  }
+}

--- a/test/codec_test.gleam
+++ b/test/codec_test.gleam
@@ -1,0 +1,642 @@
+import gleam/dict
+import gleam/int
+import gleam/option.{None, Some}
+import gleam/string
+import gleeunit/should
+import msgpack_gleam
+import msgpack_gleam/codec.{type Codec}
+import msgpack_gleam/value
+
+// ============================================================================
+// Test Types
+// ============================================================================
+
+pub type Person {
+  Person(name: String, age: Int)
+}
+
+pub type User {
+  User(id: Int, name: String, email: option.Option(String), tags: List(String))
+}
+
+pub type Point {
+  Point(x: Float, y: Float)
+}
+
+pub type TreeNode {
+  Leaf(val: Int)
+  Branch(left: TreeNode, right: TreeNode)
+}
+
+// ============================================================================
+// Primitive Codec Tests
+// ============================================================================
+
+pub fn bool_codec_test() {
+  let c = codec.bool()
+
+  // Encode
+  codec.encode(c, True)
+  |> should.equal(value.Boolean(True))
+
+  codec.encode(c, False)
+  |> should.equal(value.Boolean(False))
+
+  // Decode
+  codec.decode(c, value.Boolean(True))
+  |> should.equal(Ok(True))
+
+  codec.decode(c, value.Boolean(False))
+  |> should.equal(Ok(False))
+
+  // Decode wrong type
+  codec.decode(c, value.Integer(1))
+  |> should.be_error()
+}
+
+pub fn int_codec_test() {
+  let c = codec.int()
+
+  // Encode
+  codec.encode(c, 42)
+  |> should.equal(value.Integer(42))
+
+  codec.encode(c, -100)
+  |> should.equal(value.Integer(-100))
+
+  // Decode
+  codec.decode(c, value.Integer(42))
+  |> should.equal(Ok(42))
+
+  // Decode wrong type
+  codec.decode(c, value.String("42"))
+  |> should.be_error()
+}
+
+pub fn float_codec_test() {
+  let c = codec.float()
+
+  // Encode
+  codec.encode(c, 3.14)
+  |> should.equal(value.Float(3.14))
+
+  // Decode
+  codec.decode(c, value.Float(3.14))
+  |> should.equal(Ok(3.14))
+
+  // Decode integer as float (coercion)
+  codec.decode(c, value.Integer(42))
+  |> should.equal(Ok(42.0))
+
+  // Decode wrong type
+  codec.decode(c, value.String("3.14"))
+  |> should.be_error()
+}
+
+pub fn float_strict_codec_test() {
+  let c = codec.float_strict()
+
+  // Decode float
+  codec.decode(c, value.Float(3.14))
+  |> should.equal(Ok(3.14))
+
+  // Decode integer fails (no coercion)
+  codec.decode(c, value.Integer(42))
+  |> should.be_error()
+}
+
+pub fn string_codec_test() {
+  let c = codec.string()
+
+  // Encode
+  codec.encode(c, "hello")
+  |> should.equal(value.String("hello"))
+
+  // Decode
+  codec.decode(c, value.String("world"))
+  |> should.equal(Ok("world"))
+
+  // Decode wrong type
+  codec.decode(c, value.Integer(42))
+  |> should.be_error()
+}
+
+pub fn binary_codec_test() {
+  let c = codec.binary()
+
+  // Encode
+  codec.encode(c, <<1, 2, 3>>)
+  |> should.equal(value.Binary(<<1, 2, 3>>))
+
+  // Decode
+  codec.decode(c, value.Binary(<<4, 5, 6>>))
+  |> should.equal(Ok(<<4, 5, 6>>))
+}
+
+// ============================================================================
+// Composite Codec Tests
+// ============================================================================
+
+pub fn nullable_codec_test() {
+  let c = codec.nullable(codec.string())
+
+  // Encode Some
+  codec.encode(c, Some("hello"))
+  |> should.equal(value.String("hello"))
+
+  // Encode None
+  codec.encode(c, None)
+  |> should.equal(value.Nil)
+
+  // Decode Some
+  codec.decode(c, value.String("hello"))
+  |> should.equal(Ok(Some("hello")))
+
+  // Decode None
+  codec.decode(c, value.Nil)
+  |> should.equal(Ok(None))
+}
+
+pub fn list_codec_test() {
+  let c = codec.list(codec.int())
+
+  // Encode
+  codec.encode(c, [1, 2, 3])
+  |> should.equal(
+    value.Array([value.Integer(1), value.Integer(2), value.Integer(3)]),
+  )
+
+  // Decode
+  codec.decode(c, value.Array([value.Integer(4), value.Integer(5)]))
+  |> should.equal(Ok([4, 5]))
+
+  // Decode empty list
+  codec.decode(c, value.Array([]))
+  |> should.equal(Ok([]))
+
+  // Decode wrong element type
+  codec.decode(c, value.Array([value.Integer(1), value.String("two")]))
+  |> should.be_error()
+}
+
+pub fn string_dict_codec_test() {
+  let c = codec.string_dict(codec.int())
+
+  // Encode
+  let d = dict.from_list([#("a", 1), #("b", 2)])
+  let encoded = codec.encode(c, d)
+
+  // Decode back
+  let assert Ok(decoded) = codec.decode(c, encoded)
+  dict.get(decoded, "a")
+  |> should.equal(Ok(1))
+  dict.get(decoded, "b")
+  |> should.equal(Ok(2))
+}
+
+pub fn dict_codec_test() {
+  let c = codec.dict(codec.int(), codec.string())
+
+  // Encode
+  let d = dict.from_list([#(1, "one"), #(2, "two")])
+  let encoded = codec.encode(c, d)
+
+  // Decode back
+  let assert Ok(decoded) = codec.decode(c, encoded)
+  dict.get(decoded, 1)
+  |> should.equal(Ok("one"))
+  dict.get(decoded, 2)
+  |> should.equal(Ok("two"))
+}
+
+// ============================================================================
+// Object Codec Tests
+// ============================================================================
+
+fn person_codec() -> Codec(Person) {
+  codec.object2(
+    Person,
+    codec.field("name", codec.string(), fn(p: Person) { p.name }),
+    codec.field("age", codec.int(), fn(p: Person) { p.age }),
+  )
+}
+
+pub fn object2_codec_test() {
+  let c = person_codec()
+  let person = Person("Alice", 30)
+
+  // Encode
+  let encoded = codec.encode(c, person)
+  encoded
+  |> should.equal(
+    value.Map([
+      #(value.String("name"), value.String("Alice")),
+      #(value.String("age"), value.Integer(30)),
+    ]),
+  )
+
+  // Decode
+  codec.decode(c, encoded)
+  |> should.equal(Ok(person))
+}
+
+fn user_codec() -> Codec(User) {
+  codec.object4(
+    User,
+    codec.field("id", codec.int(), fn(u: User) { u.id }),
+    codec.field("name", codec.string(), fn(u: User) { u.name }),
+    codec.field("email", codec.nullable(codec.string()), fn(u: User) { u.email }),
+    codec.field("tags", codec.list(codec.string()), fn(u: User) { u.tags }),
+  )
+}
+
+pub fn object4_codec_test() {
+  let c = user_codec()
+  let user = User(1, "Bob", Some("bob@example.com"), ["admin", "active"])
+
+  // Round-trip
+  let encoded = codec.encode(c, user)
+  codec.decode(c, encoded)
+  |> should.equal(Ok(user))
+
+  // With None email
+  let user2 = User(2, "Charlie", None, [])
+  let encoded2 = codec.encode(c, user2)
+  codec.decode(c, encoded2)
+  |> should.equal(Ok(user2))
+}
+
+pub fn missing_field_error_test() {
+  let c = person_codec()
+
+  // Missing 'age' field
+  let v = value.Map([#(value.String("name"), value.String("Alice"))])
+  let result = codec.decode(c, v)
+  result
+  |> should.be_error()
+
+  // Check error message
+  let assert Error(err) = result
+  codec.format_error(err)
+  |> should.equal("missing field \"age\"")
+}
+
+pub fn field_type_error_test() {
+  let c = person_codec()
+
+  // Wrong type for 'age'
+  let v =
+    value.Map([
+      #(value.String("name"), value.String("Alice")),
+      #(value.String("age"), value.String("thirty")),
+    ])
+  let result = codec.decode(c, v)
+  result
+  |> should.be_error()
+
+  // Check error message includes path
+  let assert Error(err) = result
+  let error_str = codec.format_error(err)
+  // Should mention the field name
+  should.be_true(string.contains(error_str, ".age"))
+}
+
+// ============================================================================
+// Tuple Codec Tests
+// ============================================================================
+
+pub fn tuple2_codec_test() {
+  let c = codec.tuple2(codec.string(), codec.int())
+
+  // Encode
+  codec.encode(c, #("hello", 42))
+  |> should.equal(value.Array([value.String("hello"), value.Integer(42)]))
+
+  // Decode
+  codec.decode(c, value.Array([value.String("world"), value.Integer(100)]))
+  |> should.equal(Ok(#("world", 100)))
+
+  // Wrong length
+  codec.decode(c, value.Array([value.String("only one")]))
+  |> should.be_error()
+}
+
+pub fn tuple3_codec_test() {
+  let c = codec.tuple3(codec.int(), codec.int(), codec.int())
+
+  // Round-trip
+  let tuple = #(1, 2, 3)
+  let encoded = codec.encode(c, tuple)
+  codec.decode(c, encoded)
+  |> should.equal(Ok(tuple))
+}
+
+// ============================================================================
+// Combinator Tests
+// ============================================================================
+
+pub fn map_codec_test() {
+  // Map Point to/from tuple
+  let point_codec =
+    codec.tuple2(codec.float(), codec.float())
+    |> codec.map(fn(p: Point) { #(p.x, p.y) }, fn(t) { Point(t.0, t.1) })
+
+  let point = Point(1.5, 2.5)
+
+  // Round-trip
+  let encoded = codec.encode(point_codec, point)
+  codec.decode(point_codec, encoded)
+  |> should.equal(Ok(point))
+}
+
+pub fn one_of_codec_test() {
+  // Accept either int or string-encoded int
+  let flexible_int =
+    codec.one_of([
+      codec.int(),
+      codec.string()
+        |> codec.try_map(fn(i) { int.to_string(i) }, fn(s) {
+          case int.parse(s) {
+            Ok(i) -> Ok(i)
+            Error(_) -> Error(codec.CustomError("Not a valid integer string"))
+          }
+        }),
+    ])
+
+  // Decode int
+  codec.decode(flexible_int, value.Integer(42))
+  |> should.equal(Ok(42))
+
+  // Decode string
+  codec.decode(flexible_int, value.String("123"))
+  |> should.equal(Ok(123))
+
+  // Invalid string
+  codec.decode(flexible_int, value.String("not a number"))
+  |> should.be_error()
+}
+
+pub fn with_default_codec_test() {
+  let c = codec.with_default(codec.int(), 0)
+
+  // Successful decode
+  codec.decode(c, value.Integer(42))
+  |> should.equal(Ok(42))
+
+  // Failed decode uses default
+  codec.decode(c, value.String("not an int"))
+  |> should.equal(Ok(0))
+
+  // Nil uses default
+  codec.decode(c, value.Nil)
+  |> should.equal(Ok(0))
+}
+
+// ============================================================================
+// Constrained Codec Tests
+// ============================================================================
+
+pub fn int_range_codec_test() {
+  let c = codec.int_range(0, 100)
+
+  // In range
+  codec.decode(c, value.Integer(50))
+  |> should.equal(Ok(50))
+
+  codec.decode(c, value.Integer(0))
+  |> should.equal(Ok(0))
+
+  codec.decode(c, value.Integer(100))
+  |> should.equal(Ok(100))
+
+  // Out of range
+  codec.decode(c, value.Integer(-1))
+  |> should.be_error()
+
+  codec.decode(c, value.Integer(101))
+  |> should.be_error()
+}
+
+pub fn non_empty_string_codec_test() {
+  let c = codec.non_empty_string()
+
+  // Non-empty
+  codec.decode(c, value.String("hello"))
+  |> should.equal(Ok("hello"))
+
+  // Empty fails
+  codec.decode(c, value.String(""))
+  |> should.be_error()
+}
+
+pub fn non_empty_list_codec_test() {
+  let c = codec.non_empty_list(codec.int())
+
+  // Non-empty
+  codec.decode(c, value.Array([value.Integer(1), value.Integer(2)]))
+  |> should.equal(Ok([1, 2]))
+
+  // Empty fails
+  codec.decode(c, value.Array([]))
+  |> should.be_error()
+}
+
+// ============================================================================
+// Lazy Codec Tests (Recursive Types)
+// ============================================================================
+
+// For sum types (variants), we need a custom codec that dispatches based on the variant.
+// This is a tagged union approach using a "type" field.
+fn tree_codec() -> Codec(TreeNode) {
+  codec.custom(
+    // Encoder: dispatch based on variant
+    fn(node) {
+      case node {
+        Leaf(v) ->
+          value.Map([
+            #(value.String("type"), value.String("leaf")),
+            #(value.String("value"), value.Integer(v)),
+          ])
+        Branch(l, r) ->
+          value.Map([
+            #(value.String("type"), value.String("branch")),
+            #(value.String("left"), codec.encode(codec.lazy(tree_codec), l)),
+            #(value.String("right"), codec.encode(codec.lazy(tree_codec), r)),
+          ])
+      }
+    },
+    // Decoder: check "type" field to determine variant
+    fn(v) {
+      case v {
+        value.Map(pairs) -> {
+          // Find the type field
+          case find_string_field(pairs, "type") {
+            Ok("leaf") -> {
+              case find_int_field(pairs, "value") {
+                Ok(val) -> Ok(Leaf(val))
+                Error(e) -> Error(e)
+              }
+            }
+            Ok("branch") -> {
+              case
+                find_value_field(pairs, "left"),
+                find_value_field(pairs, "right")
+              {
+                Ok(left_val), Ok(right_val) -> {
+                  let decoder = codec.lazy(tree_codec)
+                  case
+                    codec.decode(decoder, left_val),
+                    codec.decode(decoder, right_val)
+                  {
+                    Ok(left), Ok(right) -> Ok(Branch(left, right))
+                    Error(e), _ -> Error(codec.FieldError("left", e))
+                    _, Error(e) -> Error(codec.FieldError("right", e))
+                  }
+                }
+                Error(e), _ -> Error(e)
+                _, Error(e) -> Error(e)
+              }
+            }
+            Ok(other) -> Error(codec.CustomError("Unknown type: " <> other))
+            Error(e) -> Error(e)
+          }
+        }
+        other -> Error(codec.TypeMismatch("Map", value_type_name(other)))
+      }
+    },
+  )
+}
+
+fn find_string_field(
+  pairs: List(#(value.Value, value.Value)),
+  name: String,
+) -> Result(String, codec.DecodeError) {
+  case pairs {
+    [] -> Error(codec.MissingField(name))
+    [#(value.String(k), value.String(v)), ..rest] ->
+      case k == name {
+        True -> Ok(v)
+        False -> find_string_field(rest, name)
+      }
+    [#(value.String(k), other), ..rest] ->
+      case k == name {
+        True -> Error(codec.TypeMismatch("String", value_type_name(other)))
+        False -> find_string_field(rest, name)
+      }
+    [_, ..rest] -> find_string_field(rest, name)
+  }
+}
+
+fn find_int_field(
+  pairs: List(#(value.Value, value.Value)),
+  name: String,
+) -> Result(Int, codec.DecodeError) {
+  case pairs {
+    [] -> Error(codec.MissingField(name))
+    [#(value.String(k), value.Integer(v)), ..rest] ->
+      case k == name {
+        True -> Ok(v)
+        False -> find_int_field(rest, name)
+      }
+    [#(value.String(k), other), ..rest] ->
+      case k == name {
+        True -> Error(codec.TypeMismatch("Integer", value_type_name(other)))
+        False -> find_int_field(rest, name)
+      }
+    [_, ..rest] -> find_int_field(rest, name)
+  }
+}
+
+fn find_value_field(
+  pairs: List(#(value.Value, value.Value)),
+  name: String,
+) -> Result(value.Value, codec.DecodeError) {
+  case pairs {
+    [] -> Error(codec.MissingField(name))
+    [#(value.String(k), v), ..rest] ->
+      case k == name {
+        True -> Ok(v)
+        False -> find_value_field(rest, name)
+      }
+    [_, ..rest] -> find_value_field(rest, name)
+  }
+}
+
+fn value_type_name(v: value.Value) -> String {
+  case v {
+    value.Nil -> "Nil"
+    value.Boolean(_) -> "Boolean"
+    value.Integer(_) -> "Integer"
+    value.Float(_) -> "Float"
+    value.String(_) -> "String"
+    value.Binary(_) -> "Binary"
+    value.Array(_) -> "Array"
+    value.Map(_) -> "Map"
+    value.Extension(_, _) -> "Extension"
+  }
+}
+
+pub fn recursive_codec_test() {
+  let c = tree_codec()
+
+  // Simple leaf
+  let leaf = Leaf(42)
+  let encoded_leaf = codec.encode(c, leaf)
+  codec.decode(c, encoded_leaf)
+  |> should.equal(Ok(leaf))
+
+  // Branch with leaves
+  let tree = Branch(Leaf(1), Leaf(2))
+  let encoded_tree = codec.encode(c, tree)
+  codec.decode(c, encoded_tree)
+  |> should.equal(Ok(tree))
+
+  // Nested branches
+  let nested = Branch(Branch(Leaf(1), Leaf(2)), Leaf(3))
+  let encoded_nested = codec.encode(c, nested)
+  codec.decode(c, encoded_nested)
+  |> should.equal(Ok(nested))
+}
+
+// ============================================================================
+// Full Round-Trip with MessagePack Binary
+// ============================================================================
+
+pub fn full_roundtrip_test() {
+  let c = user_codec()
+  let user = User(42, "Test User", Some("test@example.com"), ["tag1", "tag2"])
+
+  // Encode to Value
+  let v = codec.encode(c, user)
+
+  // Pack to binary
+  let assert Ok(bytes) = msgpack_gleam.pack(v)
+
+  // Unpack from binary
+  let assert Ok(decoded_value) = msgpack_gleam.unpack_exact(bytes)
+
+  // Decode from Value
+  let assert Ok(decoded_user) = codec.decode(c, decoded_value)
+
+  decoded_user
+  |> should.equal(user)
+}
+
+pub fn nested_structure_roundtrip_test() {
+  // List of users
+  let c = codec.list(user_codec())
+  let users = [
+    User(1, "Alice", Some("alice@example.com"), ["admin"]),
+    User(2, "Bob", None, []),
+    User(3, "Charlie", Some("charlie@example.com"), ["user", "beta"]),
+  ]
+
+  // Full round-trip
+  let v = codec.encode(c, users)
+  let assert Ok(bytes) = msgpack_gleam.pack(v)
+  let assert Ok(decoded_value) = msgpack_gleam.unpack_exact(bytes)
+  let assert Ok(decoded_users) = codec.decode(c, decoded_value)
+
+  decoded_users
+  |> should.equal(users)
+}


### PR DESCRIPTION
## Summary
- Introduces a `Codec(a)` type that combines encoding and decoding into a single definition
- Eliminates duplicate code when defining both encoder and decoder for a type
- Provides composable combinators for building complex codecs

## Features
- **Primitives**: `bool()`, `int()`, `float()`, `string()`, `binary()`
- **Nullable**: `nullable(codec)` for `Option` types
- **Collections**: `list(codec)`, `dict(key, val)`, `string_dict(val)`
- **Objects**: `object1` through `object8` with `field()` helper
- **Tuples**: `tuple2` through `tuple4`
- **Combinators**: `map()`, `try_map()`, `one_of()`, `lazy()`, `custom()`
- **Error handling**: Comprehensive `DecodeError` types with path tracking
