### PR TITLE
feat: migrate from gleeunit to startest

### DIFF
--- a/codegen/gleam.toml
+++ b/codegen/gleam.toml
@@ -13,4 +13,4 @@ argv = ">= 1.0.0 and < 2.0.0"
 glint = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
-gleeunit = ">= 1.0.0 and < 2.0.0"
+startest = ">= 0.8.0 and < 1.0.0"

--- a/codegen/manifest.toml
+++ b/codegen/manifest.toml
@@ -3,25 +3,33 @@
 
 packages = [
   { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
+  { name = "bigben", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time", "interior"], otp_app = "bigben", source = "hex", outer_checksum = "4B0D9F2514C06AE577F284532270A6F89007781620E4B12A843388BA549C17D2" },
+  { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_community_ansi", version = "1.4.3", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "8A62AE9CC6EA65BEA630D95016D6C07E4F9973565FA3D0DE68DC4200D8E0DD27" },
   { name = "gleam_community_colour", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "E34DD2C896AC3792151EDA939DA435FF3B69922F33415ED3C4406C932FBE9634" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_javascript", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_javascript", source = "hex", outer_checksum = "EF6C77A506F026C6FB37941889477CD5E4234FCD4337FF0E9384E297CB8F97EB" },
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
+  { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "0.68.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "F7FAEBD8EF260664E86A46C8DBA23508D1D11BB3BCC6EE1B89B3BC3E5C83FF1E" },
-  { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
+  { name = "gleam_time", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56DB0EF9433826D3B99DB0B4AF7A2BFED13D09755EC64B1DAAB46F804A9AD47D" },
   { name = "glexer", version = "2.3.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "41D8D2E855AEA87ADC94B7AF26A5FEA3C90268D4CF2CCBBD64FD6863714EE085" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
+  { name = "interior", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "interior", source = "hex", outer_checksum = "EE2728791E34400CB3CD986B6AD0E02A2F970F50B5ED59896E2820702C7DDD29" },
   { name = "simplifile", version = "2.3.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "E049B4DACD4D206D87843BCF4C775A50AE0F50A52031A2FFB40C9ED07D6EC70A" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
+  { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
+  { name = "tom", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "90791DA4AACE637E30081FE77049B8DB850FBC8CACC31515376BCC4E59BE1DD2" },
 ]
 
 [requirements]
 argv = { version = ">= 1.0.0 and < 2.0.0" }
 glance = { version = ">= 6.0.0 and < 7.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
-gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 glint = { version = ">= 1.0.0 and < 2.0.0" }
 simplifile = { version = ">= 2.0.0 and < 3.0.0" }
+startest = { version = ">= 0.8.0 and < 1.0.0" }

--- a/codegen/src/msgpack_codegen.gleam
+++ b/codegen/src/msgpack_codegen.gleam
@@ -16,7 +16,9 @@ pub fn main() {
     [input_path] -> run(input_path, None)
     [input_path, output_path] -> run(input_path, Some(output_path))
     _ -> {
-      io.println("msgpack_codegen - Generate MessagePack codecs from Gleam types")
+      io.println(
+        "msgpack_codegen - Generate MessagePack codecs from Gleam types",
+      )
       io.println("")
       io.println("Usage:")
       io.println("  gleam run -m msgpack_codegen -- <input_file> [output_file]")
@@ -30,7 +32,9 @@ pub fn main() {
       io.println("")
       io.println("Examples:")
       io.println("  gleam run -m msgpack_codegen -- src/types.gleam")
-      io.println("  gleam run -m msgpack_codegen -- src/types.gleam src/types_codec.gleam")
+      io.println(
+        "  gleam run -m msgpack_codegen -- src/types.gleam src/types_codec.gleam",
+      )
     }
   }
 }

--- a/codegen/test/msgpack_codegen_test.gleam
+++ b/codegen/test/msgpack_codegen_test.gleam
@@ -1,9 +1,9 @@
-import gleeunit
-import gleeunit/should
 import msgpack_codegen/generator
+import startest
+import startest/expect
 
 pub fn main() {
-  gleeunit.main()
+  startest.run(startest.default_config())
 }
 
 const simple_record_source = "
@@ -43,42 +43,42 @@ pub fn parse_simple_record_test() {
   let assert Ok(result) = generator.parse_source(simple_record_source)
 
   result.types_to_generate
-  |> should.not_equal([])
+  |> expect.to_not_equal([])
 
   case result.types_to_generate {
     [generator.RecordType(name, params, fields, is_public)] -> {
       name
-      |> should.equal("User")
+      |> expect.to_equal("User")
 
       params
-      |> should.equal([])
+      |> expect.to_equal([])
 
       is_public
-      |> should.be_true()
+      |> expect.to_be_true()
 
       case fields {
         [f1, f2, f3] -> {
           f1.name
-          |> should.equal("id")
+          |> expect.to_equal("id")
           f1.gleam_type
-          |> should.equal("Int")
+          |> expect.to_equal("Int")
           f1.is_optional
-          |> should.be_false()
+          |> expect.to_be_false()
 
           f2.name
-          |> should.equal("name")
+          |> expect.to_equal("name")
           f2.gleam_type
-          |> should.equal("String")
+          |> expect.to_equal("String")
 
           f3.name
-          |> should.equal("email")
+          |> expect.to_equal("email")
           f3.is_optional
-          |> should.be_true()
+          |> expect.to_be_true()
         }
-        _ -> should.fail()
+        _ -> panic as "unreachable"
       }
     }
-    _ -> should.fail()
+    _ -> panic as "unreachable"
   }
 }
 
@@ -86,39 +86,39 @@ pub fn parse_variant_type_test() {
   let assert Ok(result) = generator.parse_source(variant_source)
 
   result.types_to_generate
-  |> should.not_equal([])
+  |> expect.to_not_equal([])
 
   case result.types_to_generate {
     [generator.VariantType(name, _, variants, _)] -> {
       name
-      |> should.equal("Status")
+      |> expect.to_equal("Status")
 
       case variants {
         [v1, v2, v3] -> {
           v1.name
-          |> should.equal("Active")
+          |> expect.to_equal("Active")
           v1.fields
-          |> should.equal([])
+          |> expect.to_equal([])
 
           v2.name
-          |> should.equal("Inactive")
+          |> expect.to_equal("Inactive")
 
           v3.name
-          |> should.equal("Pending")
+          |> expect.to_equal("Pending")
           case v3.fields {
             [f] -> {
               f.name
-              |> should.equal("reason")
+              |> expect.to_equal("reason")
               f.gleam_type
-              |> should.equal("String")
+              |> expect.to_equal("String")
             }
-            _ -> should.fail()
+            _ -> panic as "unreachable"
           }
         }
-        _ -> should.fail()
+        _ -> panic as "unreachable"
       }
     }
-    _ -> should.fail()
+    _ -> panic as "unreachable"
   }
 }
 
@@ -126,7 +126,7 @@ pub fn skip_unmarked_types_test() {
   let assert Ok(result) = generator.parse_source(no_derive_source)
 
   result.types_to_generate
-  |> should.equal([])
+  |> expect.to_equal([])
 }
 
 pub fn generate_record_codec_test() {
@@ -135,13 +135,13 @@ pub fn generate_record_codec_test() {
     generator.generate_codecs(result, generator.default_config())
 
   // Check that generated code contains expected elements
-  should.be_true(contains(generated, "fn user_codec()"))
-  should.be_true(contains(generated, "Codec(User)"))
-  should.be_true(contains(generated, "codec.object3"))
-  should.be_true(contains(generated, "codec.field(\"id\""))
-  should.be_true(contains(generated, "codec.field(\"name\""))
-  should.be_true(contains(generated, "codec.field(\"email\""))
-  should.be_true(contains(generated, "codec.nullable(codec.string())"))
+  expect.to_be_true(contains(generated, "fn user_codec()"))
+  expect.to_be_true(contains(generated, "Codec(User)"))
+  expect.to_be_true(contains(generated, "codec.object3"))
+  expect.to_be_true(contains(generated, "codec.field(\"id\""))
+  expect.to_be_true(contains(generated, "codec.field(\"name\""))
+  expect.to_be_true(contains(generated, "codec.field(\"email\""))
+  expect.to_be_true(contains(generated, "codec.nullable(codec.string())"))
 }
 
 pub fn generate_variant_codec_test() {
@@ -150,11 +150,11 @@ pub fn generate_variant_codec_test() {
     generator.generate_codecs(result, generator.default_config())
 
   // Check that generated code contains expected elements
-  should.be_true(contains(generated, "fn status_codec()"))
-  should.be_true(contains(generated, "codec.custom"))
-  should.be_true(contains(generated, "\"active\""))
-  should.be_true(contains(generated, "\"inactive\""))
-  should.be_true(contains(generated, "\"pending\""))
+  expect.to_be_true(contains(generated, "fn status_codec()"))
+  expect.to_be_true(contains(generated, "codec.custom"))
+  expect.to_be_true(contains(generated, "\"active\""))
+  expect.to_be_true(contains(generated, "\"inactive\""))
+  expect.to_be_true(contains(generated, "\"pending\""))
 }
 
 pub fn generate_nested_types_codec_test() {
@@ -163,8 +163,8 @@ pub fn generate_nested_types_codec_test() {
     generator.generate_codecs(result, generator.default_config())
 
   // Check for list and dict codec usage
-  should.be_true(contains(generated, "codec.list(codec.string())"))
-  should.be_true(contains(generated, "codec.string_dict(codec.string())"))
+  expect.to_be_true(contains(generated, "codec.list(codec.string())"))
+  expect.to_be_true(contains(generated, "codec.string_dict(codec.string())"))
 }
 
 fn contains(haystack: String, needle: String) -> Bool {

--- a/gleam.toml
+++ b/gleam.toml
@@ -9,6 +9,6 @@ target = "erlang"
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 
 [dev-dependencies]
-gleeunit = ">= 1.0.0 and < 2.0.0"
 gleam_json = ">= 3.0.0 and < 4.0.0"
 simplifile = ">= 2.0.0 and < 3.0.0"
+startest = ">= 0.8.0 and < 1.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,15 +2,29 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
+  { name = "bigben", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time", "interior"], otp_app = "bigben", source = "hex", outer_checksum = "4B0D9F2514C06AE577F284532270A6F89007781620E4B12A843388BA549C17D2" },
+  { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
+  { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_javascript", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_javascript", source = "hex", outer_checksum = "EF6C77A506F026C6FB37941889477CD5E4234FCD4337FF0E9384E297CB8F97EB" },
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
+  { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
+  { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "0.68.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "F7FAEBD8EF260664E86A46C8DBA23508D1D11BB3BCC6EE1B89B3BC3E5C83FF1E" },
-  { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
+  { name = "gleam_time", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56DB0EF9433826D3B99DB0B4AF7A2BFED13D09755EC64B1DAAB46F804A9AD47D" },
+  { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
+  { name = "interior", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "interior", source = "hex", outer_checksum = "EE2728791E34400CB3CD986B6AD0E02A2F970F50B5ED59896E2820702C7DDD29" },
   { name = "simplifile", version = "2.3.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "E049B4DACD4D206D87843BCF4C775A50AE0F50A52031A2FFB40C9ED07D6EC70A" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
+  { name = "tom", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "90791DA4AACE637E30081FE77049B8DB850FBC8CACC31515376BCC4E59BE1DD2" },
 ]
 
 [requirements]
 gleam_json = { version = ">= 3.0.0 and < 4.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
-gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 simplifile = { version = ">= 2.0.0 and < 3.0.0" }
+startest = { version = ">= 0.8.0 and < 1.0.0" }

--- a/test/codec_test.gleam
+++ b/test/codec_test.gleam
@@ -2,10 +2,10 @@ import gleam/dict
 import gleam/int
 import gleam/option.{None, Some}
 import gleam/string
-import gleeunit/should
 import msgpack_gleam
 import msgpack_gleam/codec.{type Codec}
 import msgpack_gleam/value
+import startest/expect
 
 // ============================================================================
 // Test Types
@@ -37,21 +37,21 @@ pub fn bool_codec_test() {
 
   // Encode
   codec.encode(c, True)
-  |> should.equal(value.Boolean(True))
+  |> expect.to_equal(value.Boolean(True))
 
   codec.encode(c, False)
-  |> should.equal(value.Boolean(False))
+  |> expect.to_equal(value.Boolean(False))
 
   // Decode
   codec.decode(c, value.Boolean(True))
-  |> should.equal(Ok(True))
+  |> expect.to_equal(Ok(True))
 
   codec.decode(c, value.Boolean(False))
-  |> should.equal(Ok(False))
+  |> expect.to_equal(Ok(False))
 
   // Decode wrong type
-  codec.decode(c, value.Integer(1))
-  |> should.be_error()
+  let _ = codec.decode(c, value.Integer(1)) |> expect.to_be_error()
+  Nil
 }
 
 pub fn int_codec_test() {
@@ -59,18 +59,18 @@ pub fn int_codec_test() {
 
   // Encode
   codec.encode(c, 42)
-  |> should.equal(value.Integer(42))
+  |> expect.to_equal(value.Integer(42))
 
   codec.encode(c, -100)
-  |> should.equal(value.Integer(-100))
+  |> expect.to_equal(value.Integer(-100))
 
   // Decode
   codec.decode(c, value.Integer(42))
-  |> should.equal(Ok(42))
+  |> expect.to_equal(Ok(42))
 
   // Decode wrong type
-  codec.decode(c, value.String("42"))
-  |> should.be_error()
+  let _ = codec.decode(c, value.String("42")) |> expect.to_be_error()
+  Nil
 }
 
 pub fn float_codec_test() {
@@ -78,19 +78,19 @@ pub fn float_codec_test() {
 
   // Encode
   codec.encode(c, 3.14)
-  |> should.equal(value.Float(3.14))
+  |> expect.to_equal(value.Float(3.14))
 
   // Decode
   codec.decode(c, value.Float(3.14))
-  |> should.equal(Ok(3.14))
+  |> expect.to_equal(Ok(3.14))
 
   // Decode integer as float (coercion)
   codec.decode(c, value.Integer(42))
-  |> should.equal(Ok(42.0))
+  |> expect.to_equal(Ok(42.0))
 
   // Decode wrong type
-  codec.decode(c, value.String("3.14"))
-  |> should.be_error()
+  let _ = codec.decode(c, value.String("3.14")) |> expect.to_be_error()
+  Nil
 }
 
 pub fn float_strict_codec_test() {
@@ -98,11 +98,11 @@ pub fn float_strict_codec_test() {
 
   // Decode float
   codec.decode(c, value.Float(3.14))
-  |> should.equal(Ok(3.14))
+  |> expect.to_equal(Ok(3.14))
 
   // Decode integer fails (no coercion)
-  codec.decode(c, value.Integer(42))
-  |> should.be_error()
+  let _ = codec.decode(c, value.Integer(42)) |> expect.to_be_error()
+  Nil
 }
 
 pub fn string_codec_test() {
@@ -110,15 +110,15 @@ pub fn string_codec_test() {
 
   // Encode
   codec.encode(c, "hello")
-  |> should.equal(value.String("hello"))
+  |> expect.to_equal(value.String("hello"))
 
   // Decode
   codec.decode(c, value.String("world"))
-  |> should.equal(Ok("world"))
+  |> expect.to_equal(Ok("world"))
 
   // Decode wrong type
-  codec.decode(c, value.Integer(42))
-  |> should.be_error()
+  let _ = codec.decode(c, value.Integer(42)) |> expect.to_be_error()
+  Nil
 }
 
 pub fn binary_codec_test() {
@@ -126,11 +126,11 @@ pub fn binary_codec_test() {
 
   // Encode
   codec.encode(c, <<1, 2, 3>>)
-  |> should.equal(value.Binary(<<1, 2, 3>>))
+  |> expect.to_equal(value.Binary(<<1, 2, 3>>))
 
   // Decode
   codec.decode(c, value.Binary(<<4, 5, 6>>))
-  |> should.equal(Ok(<<4, 5, 6>>))
+  |> expect.to_equal(Ok(<<4, 5, 6>>))
 }
 
 // ============================================================================
@@ -142,19 +142,19 @@ pub fn nullable_codec_test() {
 
   // Encode Some
   codec.encode(c, Some("hello"))
-  |> should.equal(value.String("hello"))
+  |> expect.to_equal(value.String("hello"))
 
   // Encode None
   codec.encode(c, None)
-  |> should.equal(value.Nil)
+  |> expect.to_equal(value.Nil)
 
   // Decode Some
   codec.decode(c, value.String("hello"))
-  |> should.equal(Ok(Some("hello")))
+  |> expect.to_equal(Ok(Some("hello")))
 
   // Decode None
   codec.decode(c, value.Nil)
-  |> should.equal(Ok(None))
+  |> expect.to_equal(Ok(None))
 }
 
 pub fn list_codec_test() {
@@ -162,21 +162,23 @@ pub fn list_codec_test() {
 
   // Encode
   codec.encode(c, [1, 2, 3])
-  |> should.equal(
+  |> expect.to_equal(
     value.Array([value.Integer(1), value.Integer(2), value.Integer(3)]),
   )
 
   // Decode
   codec.decode(c, value.Array([value.Integer(4), value.Integer(5)]))
-  |> should.equal(Ok([4, 5]))
+  |> expect.to_equal(Ok([4, 5]))
 
   // Decode empty list
   codec.decode(c, value.Array([]))
-  |> should.equal(Ok([]))
+  |> expect.to_equal(Ok([]))
 
   // Decode wrong element type
-  codec.decode(c, value.Array([value.Integer(1), value.String("two")]))
-  |> should.be_error()
+  let _ =
+    codec.decode(c, value.Array([value.Integer(1), value.String("two")]))
+    |> expect.to_be_error()
+  Nil
 }
 
 pub fn string_dict_codec_test() {
@@ -189,9 +191,9 @@ pub fn string_dict_codec_test() {
   // Decode back
   let assert Ok(decoded) = codec.decode(c, encoded)
   dict.get(decoded, "a")
-  |> should.equal(Ok(1))
+  |> expect.to_equal(Ok(1))
   dict.get(decoded, "b")
-  |> should.equal(Ok(2))
+  |> expect.to_equal(Ok(2))
 }
 
 pub fn dict_codec_test() {
@@ -204,9 +206,9 @@ pub fn dict_codec_test() {
   // Decode back
   let assert Ok(decoded) = codec.decode(c, encoded)
   dict.get(decoded, 1)
-  |> should.equal(Ok("one"))
+  |> expect.to_equal(Ok("one"))
   dict.get(decoded, 2)
-  |> should.equal(Ok("two"))
+  |> expect.to_equal(Ok("two"))
 }
 
 // ============================================================================
@@ -228,7 +230,7 @@ pub fn object2_codec_test() {
   // Encode
   let encoded = codec.encode(c, person)
   encoded
-  |> should.equal(
+  |> expect.to_equal(
     value.Map([
       #(value.String("name"), value.String("Alice")),
       #(value.String("age"), value.Integer(30)),
@@ -237,7 +239,7 @@ pub fn object2_codec_test() {
 
   // Decode
   codec.decode(c, encoded)
-  |> should.equal(Ok(person))
+  |> expect.to_equal(Ok(person))
 }
 
 fn user_codec() -> Codec(User) {
@@ -257,13 +259,13 @@ pub fn object4_codec_test() {
   // Round-trip
   let encoded = codec.encode(c, user)
   codec.decode(c, encoded)
-  |> should.equal(Ok(user))
+  |> expect.to_equal(Ok(user))
 
   // With None email
   let user2 = User(2, "Charlie", None, [])
   let encoded2 = codec.encode(c, user2)
   codec.decode(c, encoded2)
-  |> should.equal(Ok(user2))
+  |> expect.to_equal(Ok(user2))
 }
 
 pub fn missing_field_error_test() {
@@ -272,13 +274,12 @@ pub fn missing_field_error_test() {
   // Missing 'age' field
   let v = value.Map([#(value.String("name"), value.String("Alice"))])
   let result = codec.decode(c, v)
-  result
-  |> should.be_error()
+  let _ = result |> expect.to_be_error()
 
   // Check error message
   let assert Error(err) = result
   codec.format_error(err)
-  |> should.equal("missing field \"age\"")
+  |> expect.to_equal("missing field \"age\"")
 }
 
 pub fn field_type_error_test() {
@@ -291,14 +292,13 @@ pub fn field_type_error_test() {
       #(value.String("age"), value.String("thirty")),
     ])
   let result = codec.decode(c, v)
-  result
-  |> should.be_error()
+  let _ = result |> expect.to_be_error()
 
   // Check error message includes path
   let assert Error(err) = result
   let error_str = codec.format_error(err)
   // Should mention the field name
-  should.be_true(string.contains(error_str, ".age"))
+  expect.to_be_true(string.contains(error_str, ".age"))
 }
 
 // ============================================================================
@@ -310,15 +310,17 @@ pub fn tuple2_codec_test() {
 
   // Encode
   codec.encode(c, #("hello", 42))
-  |> should.equal(value.Array([value.String("hello"), value.Integer(42)]))
+  |> expect.to_equal(value.Array([value.String("hello"), value.Integer(42)]))
 
   // Decode
   codec.decode(c, value.Array([value.String("world"), value.Integer(100)]))
-  |> should.equal(Ok(#("world", 100)))
+  |> expect.to_equal(Ok(#("world", 100)))
 
   // Wrong length
-  codec.decode(c, value.Array([value.String("only one")]))
-  |> should.be_error()
+  let _ =
+    codec.decode(c, value.Array([value.String("only one")]))
+    |> expect.to_be_error()
+  Nil
 }
 
 pub fn tuple3_codec_test() {
@@ -328,7 +330,7 @@ pub fn tuple3_codec_test() {
   let tuple = #(1, 2, 3)
   let encoded = codec.encode(c, tuple)
   codec.decode(c, encoded)
-  |> should.equal(Ok(tuple))
+  |> expect.to_equal(Ok(tuple))
 }
 
 // ============================================================================
@@ -346,7 +348,7 @@ pub fn map_codec_test() {
   // Round-trip
   let encoded = codec.encode(point_codec, point)
   codec.decode(point_codec, encoded)
-  |> should.equal(Ok(point))
+  |> expect.to_equal(Ok(point))
 }
 
 pub fn one_of_codec_test() {
@@ -365,15 +367,17 @@ pub fn one_of_codec_test() {
 
   // Decode int
   codec.decode(flexible_int, value.Integer(42))
-  |> should.equal(Ok(42))
+  |> expect.to_equal(Ok(42))
 
   // Decode string
   codec.decode(flexible_int, value.String("123"))
-  |> should.equal(Ok(123))
+  |> expect.to_equal(Ok(123))
 
   // Invalid string
-  codec.decode(flexible_int, value.String("not a number"))
-  |> should.be_error()
+  let _ =
+    codec.decode(flexible_int, value.String("not a number"))
+    |> expect.to_be_error()
+  Nil
 }
 
 pub fn with_default_codec_test() {
@@ -381,15 +385,15 @@ pub fn with_default_codec_test() {
 
   // Successful decode
   codec.decode(c, value.Integer(42))
-  |> should.equal(Ok(42))
+  |> expect.to_equal(Ok(42))
 
   // Failed decode uses default
   codec.decode(c, value.String("not an int"))
-  |> should.equal(Ok(0))
+  |> expect.to_equal(Ok(0))
 
   // Nil uses default
   codec.decode(c, value.Nil)
-  |> should.equal(Ok(0))
+  |> expect.to_equal(Ok(0))
 }
 
 // ============================================================================
@@ -401,20 +405,18 @@ pub fn int_range_codec_test() {
 
   // In range
   codec.decode(c, value.Integer(50))
-  |> should.equal(Ok(50))
+  |> expect.to_equal(Ok(50))
 
   codec.decode(c, value.Integer(0))
-  |> should.equal(Ok(0))
+  |> expect.to_equal(Ok(0))
 
   codec.decode(c, value.Integer(100))
-  |> should.equal(Ok(100))
+  |> expect.to_equal(Ok(100))
 
   // Out of range
-  codec.decode(c, value.Integer(-1))
-  |> should.be_error()
-
-  codec.decode(c, value.Integer(101))
-  |> should.be_error()
+  let _ = codec.decode(c, value.Integer(-1)) |> expect.to_be_error()
+  let _ = codec.decode(c, value.Integer(101)) |> expect.to_be_error()
+  Nil
 }
 
 pub fn non_empty_string_codec_test() {
@@ -422,11 +424,11 @@ pub fn non_empty_string_codec_test() {
 
   // Non-empty
   codec.decode(c, value.String("hello"))
-  |> should.equal(Ok("hello"))
+  |> expect.to_equal(Ok("hello"))
 
   // Empty fails
-  codec.decode(c, value.String(""))
-  |> should.be_error()
+  let _ = codec.decode(c, value.String("")) |> expect.to_be_error()
+  Nil
 }
 
 pub fn non_empty_list_codec_test() {
@@ -434,11 +436,11 @@ pub fn non_empty_list_codec_test() {
 
   // Non-empty
   codec.decode(c, value.Array([value.Integer(1), value.Integer(2)]))
-  |> should.equal(Ok([1, 2]))
+  |> expect.to_equal(Ok([1, 2]))
 
   // Empty fails
-  codec.decode(c, value.Array([]))
-  |> should.be_error()
+  let _ = codec.decode(c, value.Array([])) |> expect.to_be_error()
+  Nil
 }
 
 // ============================================================================
@@ -583,19 +585,19 @@ pub fn recursive_codec_test() {
   let leaf = Leaf(42)
   let encoded_leaf = codec.encode(c, leaf)
   codec.decode(c, encoded_leaf)
-  |> should.equal(Ok(leaf))
+  |> expect.to_equal(Ok(leaf))
 
   // Branch with leaves
   let tree = Branch(Leaf(1), Leaf(2))
   let encoded_tree = codec.encode(c, tree)
   codec.decode(c, encoded_tree)
-  |> should.equal(Ok(tree))
+  |> expect.to_equal(Ok(tree))
 
   // Nested branches
   let nested = Branch(Branch(Leaf(1), Leaf(2)), Leaf(3))
   let encoded_nested = codec.encode(c, nested)
   codec.decode(c, encoded_nested)
-  |> should.equal(Ok(nested))
+  |> expect.to_equal(Ok(nested))
 }
 
 // ============================================================================
@@ -619,7 +621,7 @@ pub fn full_roundtrip_test() {
   let assert Ok(decoded_user) = codec.decode(c, decoded_value)
 
   decoded_user
-  |> should.equal(user)
+  |> expect.to_equal(user)
 }
 
 pub fn nested_structure_roundtrip_test() {
@@ -638,5 +640,5 @@ pub fn nested_structure_roundtrip_test() {
   let assert Ok(decoded_users) = codec.decode(c, decoded_value)
 
   decoded_users
-  |> should.equal(users)
+  |> expect.to_equal(users)
 }

--- a/test/msgpack_gleam_test.gleam
+++ b/test/msgpack_gleam_test.gleam
@@ -1,19 +1,19 @@
 import gleam/dict
 import gleam/list
-import gleeunit
-import gleeunit/should
 import msgpack_gleam.{pack, unpack, unpack_exact}
 import msgpack_gleam/timestamp.{Timestamp}
 import msgpack_gleam/value.{
   Array, Binary, Boolean, Extension, Float, Integer, Map, Nil, String,
 }
+import startest
+import startest/expect
 import test_helpers.{
   BoolValue, IntValue, NilValue, StringValue, TestCase, bits_to_hex,
   get_test_cases, hex_to_bits, load_test_suite,
 }
 
-pub fn main() -> Nil {
-  gleeunit.main()
+pub fn main() {
+  startest.run(startest.default_config())
 }
 
 // ============================================================================
@@ -22,31 +22,31 @@ pub fn main() -> Nil {
 
 pub fn load_test_suite_test() {
   let result = load_test_suite("test/test_data/msgpack-test-suite.json")
-  should.be_ok(result)
+  expect.to_be_ok(result)
 
   let assert Ok(suite) = result
   // Verify all expected sections are present
-  dict.size(suite) |> should.equal(15)
+  dict.size(suite) |> expect.to_equal(15)
 
   // Verify some specific sections
-  get_test_cases(suite, "10.nil.yaml") |> list.length |> should.equal(1)
-  get_test_cases(suite, "11.bool.yaml") |> list.length |> should.equal(2)
+  get_test_cases(suite, "10.nil.yaml") |> list.length |> expect.to_equal(1)
+  get_test_cases(suite, "11.bool.yaml") |> list.length |> expect.to_equal(2)
 }
 
 pub fn hex_to_bits_test() {
   // Simple single byte
-  hex_to_bits("c0") |> should.equal(Ok(<<0xc0>>))
+  hex_to_bits("c0") |> expect.to_equal(Ok(<<0xc0>>))
 
   // Multiple bytes with dashes
-  hex_to_bits("c4-01-01") |> should.equal(Ok(<<0xc4, 0x01, 0x01>>))
+  hex_to_bits("c4-01-01") |> expect.to_equal(Ok(<<0xc4, 0x01, 0x01>>))
 
   // Multiple bytes without dashes
-  hex_to_bits("c40101") |> should.equal(Ok(<<0xc4, 0x01, 0x01>>))
+  hex_to_bits("c40101") |> expect.to_equal(Ok(<<0xc4, 0x01, 0x01>>))
 }
 
 pub fn bits_to_hex_test() {
-  bits_to_hex(<<0xc0>>) |> should.equal("c0")
-  bits_to_hex(<<0xc4, 0x01, 0x01>>) |> should.equal("c40101")
+  bits_to_hex(<<0xc0>>) |> expect.to_equal("c0")
+  bits_to_hex(<<0xc4, 0x01, 0x01>>) |> expect.to_equal("c40101")
 }
 
 // ============================================================================
@@ -59,11 +59,11 @@ pub fn test_suite_nil_section_test() {
   let cases = get_test_cases(suite, "10.nil.yaml")
 
   // Should have 1 test case for nil
-  list.length(cases) |> should.equal(1)
+  list.length(cases) |> expect.to_equal(1)
 
   // First case should be NilValue with encoding c0
   let assert [TestCase(value: NilValue, msgpack: encodings)] = cases
-  list.first(encodings) |> should.equal(Ok(<<0xc0>>))
+  list.first(encodings) |> expect.to_equal(Ok(<<0xc0>>))
 }
 
 pub fn test_suite_bool_section_test() {
@@ -72,12 +72,12 @@ pub fn test_suite_bool_section_test() {
   let cases = get_test_cases(suite, "11.bool.yaml")
 
   // Should have 2 test cases (false and true)
-  list.length(cases) |> should.equal(2)
+  list.length(cases) |> expect.to_equal(2)
 
   // Verify false case
   let assert [TestCase(value: BoolValue(False), msgpack: false_encodings), ..] =
     cases
-  list.first(false_encodings) |> should.equal(Ok(<<0xc2>>))
+  list.first(false_encodings) |> expect.to_equal(Ok(<<0xc2>>))
 }
 
 pub fn test_suite_positive_int_section_test() {
@@ -86,10 +86,11 @@ pub fn test_suite_positive_int_section_test() {
   let cases = get_test_cases(suite, "20.number-positive.yaml")
 
   // Should have multiple test cases
-  { cases != [] } |> should.be_true
+  { cases != [] } |> expect.to_be_true
 
   // First case should be 0
   let assert [TestCase(value: IntValue(0), msgpack: _), ..] = cases
+  Nil
 }
 
 pub fn test_suite_string_section_test() {
@@ -98,10 +99,11 @@ pub fn test_suite_string_section_test() {
   let cases = get_test_cases(suite, "30.string-ascii.yaml")
 
   // Should have test cases
-  { cases != [] } |> should.be_true
+  { cases != [] } |> expect.to_be_true
 
   // First case should be empty string
   let assert [TestCase(value: StringValue(""), msgpack: _), ..] = cases
+  Nil
 }
 
 // ============================================================================
@@ -109,12 +111,12 @@ pub fn test_suite_string_section_test() {
 // ============================================================================
 
 pub fn encode_nil_test() {
-  pack(Nil) |> should.equal(Ok(<<0xc0>>))
+  pack(Nil) |> expect.to_equal(Ok(<<0xc0>>))
 }
 
 pub fn decode_nil_test() {
-  unpack(<<0xc0>>) |> should.equal(Ok(#(Nil, <<>>)))
-  unpack_exact(<<0xc0>>) |> should.equal(Ok(Nil))
+  unpack(<<0xc0>>) |> expect.to_equal(Ok(#(Nil, <<>>)))
+  unpack_exact(<<0xc0>>) |> expect.to_equal(Ok(Nil))
 }
 
 // ============================================================================
@@ -122,13 +124,13 @@ pub fn decode_nil_test() {
 // ============================================================================
 
 pub fn encode_bool_test() {
-  pack(Boolean(False)) |> should.equal(Ok(<<0xc2>>))
-  pack(Boolean(True)) |> should.equal(Ok(<<0xc3>>))
+  pack(Boolean(False)) |> expect.to_equal(Ok(<<0xc2>>))
+  pack(Boolean(True)) |> expect.to_equal(Ok(<<0xc3>>))
 }
 
 pub fn decode_bool_test() {
-  unpack(<<0xc2>>) |> should.equal(Ok(#(Boolean(False), <<>>)))
-  unpack(<<0xc3>>) |> should.equal(Ok(#(Boolean(True), <<>>)))
+  unpack(<<0xc2>>) |> expect.to_equal(Ok(#(Boolean(False), <<>>)))
+  unpack(<<0xc3>>) |> expect.to_equal(Ok(#(Boolean(True), <<>>)))
 }
 
 // ============================================================================
@@ -137,91 +139,93 @@ pub fn decode_bool_test() {
 
 pub fn encode_positive_fixint_test() {
   // 0-127 should use fixint (single byte)
-  pack(Integer(0)) |> should.equal(Ok(<<0x00>>))
-  pack(Integer(1)) |> should.equal(Ok(<<0x01>>))
-  pack(Integer(127)) |> should.equal(Ok(<<0x7f>>))
+  pack(Integer(0)) |> expect.to_equal(Ok(<<0x00>>))
+  pack(Integer(1)) |> expect.to_equal(Ok(<<0x01>>))
+  pack(Integer(127)) |> expect.to_equal(Ok(<<0x7f>>))
 }
 
 pub fn decode_positive_fixint_test() {
-  unpack(<<0x00>>) |> should.equal(Ok(#(Integer(0), <<>>)))
-  unpack(<<0x01>>) |> should.equal(Ok(#(Integer(1), <<>>)))
-  unpack(<<0x7f>>) |> should.equal(Ok(#(Integer(127), <<>>)))
+  unpack(<<0x00>>) |> expect.to_equal(Ok(#(Integer(0), <<>>)))
+  unpack(<<0x01>>) |> expect.to_equal(Ok(#(Integer(1), <<>>)))
+  unpack(<<0x7f>>) |> expect.to_equal(Ok(#(Integer(127), <<>>)))
 }
 
 pub fn encode_negative_fixint_test() {
   // -32 to -1 should use negative fixint
-  pack(Integer(-1)) |> should.equal(Ok(<<0xff>>))
-  pack(Integer(-32)) |> should.equal(Ok(<<0xe0>>))
+  pack(Integer(-1)) |> expect.to_equal(Ok(<<0xff>>))
+  pack(Integer(-32)) |> expect.to_equal(Ok(<<0xe0>>))
 }
 
 pub fn decode_negative_fixint_test() {
-  unpack(<<0xff>>) |> should.equal(Ok(#(Integer(-1), <<>>)))
-  unpack(<<0xe0>>) |> should.equal(Ok(#(Integer(-32), <<>>)))
+  unpack(<<0xff>>) |> expect.to_equal(Ok(#(Integer(-1), <<>>)))
+  unpack(<<0xe0>>) |> expect.to_equal(Ok(#(Integer(-32), <<>>)))
 }
 
 pub fn encode_uint8_test() {
   // 128-255 should use uint8
-  pack(Integer(128)) |> should.equal(Ok(<<0xcc, 128>>))
-  pack(Integer(255)) |> should.equal(Ok(<<0xcc, 255>>))
+  pack(Integer(128)) |> expect.to_equal(Ok(<<0xcc, 128>>))
+  pack(Integer(255)) |> expect.to_equal(Ok(<<0xcc, 255>>))
 }
 
 pub fn decode_uint8_test() {
-  unpack(<<0xcc, 128>>) |> should.equal(Ok(#(Integer(128), <<>>)))
-  unpack(<<0xcc, 255>>) |> should.equal(Ok(#(Integer(255), <<>>)))
+  unpack(<<0xcc, 128>>) |> expect.to_equal(Ok(#(Integer(128), <<>>)))
+  unpack(<<0xcc, 255>>) |> expect.to_equal(Ok(#(Integer(255), <<>>)))
 }
 
 pub fn encode_int8_test() {
   // -128 to -33 should use int8
-  pack(Integer(-33)) |> should.equal(Ok(<<0xd0, 0xdf>>))
-  pack(Integer(-128)) |> should.equal(Ok(<<0xd0, 0x80>>))
+  pack(Integer(-33)) |> expect.to_equal(Ok(<<0xd0, 0xdf>>))
+  pack(Integer(-128)) |> expect.to_equal(Ok(<<0xd0, 0x80>>))
 }
 
 pub fn decode_int8_test() {
-  unpack(<<0xd0, 0xdf>>) |> should.equal(Ok(#(Integer(-33), <<>>)))
-  unpack(<<0xd0, 0x80>>) |> should.equal(Ok(#(Integer(-128), <<>>)))
+  unpack(<<0xd0, 0xdf>>) |> expect.to_equal(Ok(#(Integer(-33), <<>>)))
+  unpack(<<0xd0, 0x80>>) |> expect.to_equal(Ok(#(Integer(-128), <<>>)))
 }
 
 pub fn encode_uint16_test() {
-  pack(Integer(256)) |> should.equal(Ok(<<0xcd, 0x01, 0x00>>))
-  pack(Integer(65_535)) |> should.equal(Ok(<<0xcd, 0xff, 0xff>>))
+  pack(Integer(256)) |> expect.to_equal(Ok(<<0xcd, 0x01, 0x00>>))
+  pack(Integer(65_535)) |> expect.to_equal(Ok(<<0xcd, 0xff, 0xff>>))
 }
 
 pub fn decode_uint16_test() {
-  unpack(<<0xcd, 0x01, 0x00>>) |> should.equal(Ok(#(Integer(256), <<>>)))
-  unpack(<<0xcd, 0xff, 0xff>>) |> should.equal(Ok(#(Integer(65_535), <<>>)))
+  unpack(<<0xcd, 0x01, 0x00>>) |> expect.to_equal(Ok(#(Integer(256), <<>>)))
+  unpack(<<0xcd, 0xff, 0xff>>) |> expect.to_equal(Ok(#(Integer(65_535), <<>>)))
 }
 
 pub fn encode_int16_test() {
-  pack(Integer(-129)) |> should.equal(Ok(<<0xd1, 0xff, 0x7f>>))
-  pack(Integer(-32_768)) |> should.equal(Ok(<<0xd1, 0x80, 0x00>>))
+  pack(Integer(-129)) |> expect.to_equal(Ok(<<0xd1, 0xff, 0x7f>>))
+  pack(Integer(-32_768)) |> expect.to_equal(Ok(<<0xd1, 0x80, 0x00>>))
 }
 
 pub fn decode_int16_test() {
-  unpack(<<0xd1, 0xff, 0x7f>>) |> should.equal(Ok(#(Integer(-129), <<>>)))
-  unpack(<<0xd1, 0x80, 0x00>>) |> should.equal(Ok(#(Integer(-32_768), <<>>)))
+  unpack(<<0xd1, 0xff, 0x7f>>) |> expect.to_equal(Ok(#(Integer(-129), <<>>)))
+  unpack(<<0xd1, 0x80, 0x00>>) |> expect.to_equal(Ok(#(Integer(-32_768), <<>>)))
 }
 
 pub fn encode_uint32_test() {
-  pack(Integer(65_536)) |> should.equal(Ok(<<0xce, 0x00, 0x01, 0x00, 0x00>>))
+  pack(Integer(65_536)) |> expect.to_equal(Ok(<<0xce, 0x00, 0x01, 0x00, 0x00>>))
   pack(Integer(4_294_967_295))
-  |> should.equal(Ok(<<0xce, 0xff, 0xff, 0xff, 0xff>>))
+  |> expect.to_equal(Ok(<<0xce, 0xff, 0xff, 0xff, 0xff>>))
 }
 
 pub fn decode_uint32_test() {
   unpack(<<0xce, 0x00, 0x01, 0x00, 0x00>>)
-  |> should.equal(Ok(#(Integer(65_536), <<>>)))
+  |> expect.to_equal(Ok(#(Integer(65_536), <<>>)))
   unpack(<<0xce, 0xff, 0xff, 0xff, 0xff>>)
-  |> should.equal(Ok(#(Integer(4_294_967_295), <<>>)))
+  |> expect.to_equal(Ok(#(Integer(4_294_967_295), <<>>)))
 }
 
 pub fn encode_uint64_test() {
   pack(Integer(4_294_967_296))
-  |> should.equal(Ok(<<0xcf, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00>>))
+  |> expect.to_equal(
+    Ok(<<0xcf, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00>>),
+  )
 }
 
 pub fn decode_uint64_test() {
   unpack(<<0xcf, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00>>)
-  |> should.equal(Ok(#(Integer(4_294_967_296), <<>>)))
+  |> expect.to_equal(Ok(#(Integer(4_294_967_296), <<>>)))
 }
 
 pub fn encode_uint64_large_test() {
@@ -229,26 +233,30 @@ pub fn encode_uint64_large_test() {
   // 2^63 = 9_223_372_036_854_775_808
   let large_value = 9_223_372_036_854_775_808
   pack(Integer(large_value))
-  |> should.equal(Ok(<<0xcf, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00>>))
+  |> expect.to_equal(
+    Ok(<<0xcf, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00>>),
+  )
 }
 
 pub fn decode_uint64_large_test() {
   // Decode 2^63
   unpack(<<0xcf, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00>>)
-  |> should.equal(Ok(#(Integer(9_223_372_036_854_775_808), <<>>)))
+  |> expect.to_equal(Ok(#(Integer(9_223_372_036_854_775_808), <<>>)))
 }
 
 pub fn encode_uint64_max_test() {
   // Test maximum uint64 value: 2^64 - 1 = 18_446_744_073_709_551_615
   let max_uint64 = 18_446_744_073_709_551_615
   pack(Integer(max_uint64))
-  |> should.equal(Ok(<<0xcf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff>>))
+  |> expect.to_equal(
+    Ok(<<0xcf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff>>),
+  )
 }
 
 pub fn decode_uint64_max_test() {
   // Decode max uint64
   unpack(<<0xcf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff>>)
-  |> should.equal(Ok(#(Integer(18_446_744_073_709_551_615), <<>>)))
+  |> expect.to_equal(Ok(#(Integer(18_446_744_073_709_551_615), <<>>)))
 }
 
 pub fn roundtrip_uint64_large_test() {
@@ -266,7 +274,7 @@ pub fn roundtrip_uint64_large_test() {
     let value = Integer(n)
     let assert Ok(encoded) = pack(value)
     let assert Ok(decoded) = unpack_exact(encoded)
-    decoded |> should.equal(value)
+    decoded |> expect.to_equal(value)
   })
 }
 
@@ -279,18 +287,19 @@ pub fn encode_float_test() {
   let assert Ok(result) = pack(Float(1.0))
   // Check first byte is float64 marker
   let assert <<0xcb, _:bits>> = result
+  Nil
 }
 
 pub fn decode_float32_test() {
   // 1.0 as float32: 0x3f800000
   unpack(<<0xca, 0x3f, 0x80, 0x00, 0x00>>)
-  |> should.equal(Ok(#(Float(1.0), <<>>)))
+  |> expect.to_equal(Ok(#(Float(1.0), <<>>)))
 }
 
 pub fn decode_float64_test() {
   // 1.0 as float64
   unpack(<<0xcb, 0x3f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00>>)
-  |> should.equal(Ok(#(Float(1.0), <<>>)))
+  |> expect.to_equal(Ok(#(Float(1.0), <<>>)))
 }
 
 // ============================================================================
@@ -299,18 +308,19 @@ pub fn decode_float64_test() {
 
 pub fn encode_fixstr_test() {
   // Empty string
-  pack(String("")) |> should.equal(Ok(<<0xa0>>))
+  pack(String("")) |> expect.to_equal(Ok(<<0xa0>>))
   // "a" (1 char)
-  pack(String("a")) |> should.equal(Ok(<<0xa1, 0x61>>))
+  pack(String("a")) |> expect.to_equal(Ok(<<0xa1, 0x61>>))
   // 31 chars (max fixstr)
   let s31 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   let assert Ok(result) = pack(String(s31))
   let assert <<0xbf, _:bits>> = result
+  Nil
 }
 
 pub fn decode_fixstr_test() {
-  unpack(<<0xa0>>) |> should.equal(Ok(#(String(""), <<>>)))
-  unpack(<<0xa1, 0x61>>) |> should.equal(Ok(#(String("a"), <<>>)))
+  unpack(<<0xa0>>) |> expect.to_equal(Ok(#(String(""), <<>>)))
+  unpack(<<0xa1, 0x61>>) |> expect.to_equal(Ok(#(String("a"), <<>>)))
 }
 
 pub fn encode_str8_test() {
@@ -318,10 +328,11 @@ pub fn encode_str8_test() {
   let s32 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   let assert Ok(result) = pack(String(s32))
   let assert <<0xd9, 32, _:bits>> = result
+  Nil
 }
 
 pub fn decode_str8_test() {
-  unpack(<<0xd9, 0x01, 0x61>>) |> should.equal(Ok(#(String("a"), <<>>)))
+  unpack(<<0xd9, 0x01, 0x61>>) |> expect.to_equal(Ok(#(String("a"), <<>>)))
 }
 
 // ============================================================================
@@ -329,13 +340,13 @@ pub fn decode_str8_test() {
 // ============================================================================
 
 pub fn encode_bin8_test() {
-  pack(Binary(<<>>)) |> should.equal(Ok(<<0xc4, 0x00>>))
-  pack(Binary(<<0x01>>)) |> should.equal(Ok(<<0xc4, 0x01, 0x01>>))
+  pack(Binary(<<>>)) |> expect.to_equal(Ok(<<0xc4, 0x00>>))
+  pack(Binary(<<0x01>>)) |> expect.to_equal(Ok(<<0xc4, 0x01, 0x01>>))
 }
 
 pub fn decode_bin8_test() {
-  unpack(<<0xc4, 0x00>>) |> should.equal(Ok(#(Binary(<<>>), <<>>)))
-  unpack(<<0xc4, 0x01, 0x01>>) |> should.equal(Ok(#(Binary(<<0x01>>), <<>>)))
+  unpack(<<0xc4, 0x00>>) |> expect.to_equal(Ok(#(Binary(<<>>), <<>>)))
+  unpack(<<0xc4, 0x01, 0x01>>) |> expect.to_equal(Ok(#(Binary(<<0x01>>), <<>>)))
 }
 
 // ============================================================================
@@ -344,23 +355,23 @@ pub fn decode_bin8_test() {
 
 pub fn encode_fixarray_test() {
   // Empty array
-  pack(Array([])) |> should.equal(Ok(<<0x90>>))
+  pack(Array([])) |> expect.to_equal(Ok(<<0x90>>))
   // Array with one element
-  pack(Array([Integer(1)])) |> should.equal(Ok(<<0x91, 0x01>>))
+  pack(Array([Integer(1)])) |> expect.to_equal(Ok(<<0x91, 0x01>>))
 }
 
 pub fn decode_fixarray_test() {
-  unpack(<<0x90>>) |> should.equal(Ok(#(Array([]), <<>>)))
-  unpack(<<0x91, 0x01>>) |> should.equal(Ok(#(Array([Integer(1)]), <<>>)))
+  unpack(<<0x90>>) |> expect.to_equal(Ok(#(Array([]), <<>>)))
+  unpack(<<0x91, 0x01>>) |> expect.to_equal(Ok(#(Array([Integer(1)]), <<>>)))
 }
 
 pub fn encode_nested_array_test() {
   pack(Array([Array([])]))
-  |> should.equal(Ok(<<0x91, 0x90>>))
+  |> expect.to_equal(Ok(<<0x91, 0x90>>))
 }
 
 pub fn decode_nested_array_test() {
-  unpack(<<0x91, 0x90>>) |> should.equal(Ok(#(Array([Array([])]), <<>>)))
+  unpack(<<0x91, 0x90>>) |> expect.to_equal(Ok(#(Array([Array([])]), <<>>)))
 }
 
 // ============================================================================
@@ -369,16 +380,16 @@ pub fn decode_nested_array_test() {
 
 pub fn encode_fixmap_test() {
   // Empty map
-  pack(Map([])) |> should.equal(Ok(<<0x80>>))
+  pack(Map([])) |> expect.to_equal(Ok(<<0x80>>))
   // Map with one entry
   pack(Map([#(String("a"), Integer(1))]))
-  |> should.equal(Ok(<<0x81, 0xa1, 0x61, 0x01>>))
+  |> expect.to_equal(Ok(<<0x81, 0xa1, 0x61, 0x01>>))
 }
 
 pub fn decode_fixmap_test() {
-  unpack(<<0x80>>) |> should.equal(Ok(#(Map([]), <<>>)))
+  unpack(<<0x80>>) |> expect.to_equal(Ok(#(Map([]), <<>>)))
   unpack(<<0x81, 0xa1, 0x61, 0x01>>)
-  |> should.equal(Ok(#(Map([#(String("a"), Integer(1))]), <<>>)))
+  |> expect.to_equal(Ok(#(Map([#(String("a"), Integer(1))]), <<>>)))
 }
 
 // ============================================================================
@@ -387,23 +398,23 @@ pub fn decode_fixmap_test() {
 
 pub fn encode_fixext1_test() {
   pack(Extension(1, <<0xaa>>))
-  |> should.equal(Ok(<<0xd4, 0x01, 0xaa>>))
+  |> expect.to_equal(Ok(<<0xd4, 0x01, 0xaa>>))
 }
 
 pub fn decode_fixext1_test() {
   unpack(<<0xd4, 0x01, 0xaa>>)
-  |> should.equal(Ok(#(Extension(1, <<0xaa>>), <<>>)))
+  |> expect.to_equal(Ok(#(Extension(1, <<0xaa>>), <<>>)))
 }
 
 pub fn encode_negative_ext_type_test() {
   // Timestamp extension is type -1
   pack(Extension(-1, <<0x00, 0x00, 0x00, 0x00>>))
-  |> should.equal(Ok(<<0xd6, 0xff, 0x00, 0x00, 0x00, 0x00>>))
+  |> expect.to_equal(Ok(<<0xd6, 0xff, 0x00, 0x00, 0x00, 0x00>>))
 }
 
 pub fn decode_negative_ext_type_test() {
   unpack(<<0xd6, 0xff, 0x00, 0x00, 0x00, 0x00>>)
-  |> should.equal(Ok(#(Extension(-1, <<0x00, 0x00, 0x00, 0x00>>), <<>>)))
+  |> expect.to_equal(Ok(#(Extension(-1, <<0x00, 0x00, 0x00, 0x00>>), <<>>)))
 }
 
 // ============================================================================
@@ -414,17 +425,17 @@ pub fn roundtrip_nil_test() {
   let value = Nil
   let assert Ok(encoded) = pack(value)
   let assert Ok(decoded) = unpack_exact(encoded)
-  decoded |> should.equal(value)
+  decoded |> expect.to_equal(value)
 }
 
 pub fn roundtrip_bool_test() {
   let assert Ok(encoded_true) = pack(Boolean(True))
   let assert Ok(decoded_true) = unpack_exact(encoded_true)
-  decoded_true |> should.equal(Boolean(True))
+  decoded_true |> expect.to_equal(Boolean(True))
 
   let assert Ok(encoded_false) = pack(Boolean(False))
   let assert Ok(decoded_false) = unpack_exact(encoded_false)
-  decoded_false |> should.equal(Boolean(False))
+  decoded_false |> expect.to_equal(Boolean(False))
 }
 
 pub fn roundtrip_integers_test() {
@@ -437,7 +448,7 @@ pub fn roundtrip_integers_test() {
     let value = Integer(n)
     let assert Ok(encoded) = pack(value)
     let assert Ok(decoded) = unpack_exact(encoded)
-    decoded |> should.equal(value)
+    decoded |> expect.to_equal(value)
   })
 }
 
@@ -448,7 +459,7 @@ pub fn roundtrip_string_test() {
     let value = String(s)
     let assert Ok(encoded) = pack(value)
     let assert Ok(decoded) = unpack_exact(encoded)
-    decoded |> should.equal(value)
+    decoded |> expect.to_equal(value)
   })
 }
 
@@ -456,7 +467,7 @@ pub fn roundtrip_array_test() {
   let value = Array([Integer(1), String("two"), Boolean(True)])
   let assert Ok(encoded) = pack(value)
   let assert Ok(decoded) = unpack_exact(encoded)
-  decoded |> should.equal(value)
+  decoded |> expect.to_equal(value)
 }
 
 pub fn roundtrip_map_test() {
@@ -467,7 +478,7 @@ pub fn roundtrip_map_test() {
     ])
   let assert Ok(encoded) = pack(value)
   let assert Ok(decoded) = unpack_exact(encoded)
-  decoded |> should.equal(value)
+  decoded |> expect.to_equal(value)
 }
 
 pub fn roundtrip_complex_test() {
@@ -491,7 +502,7 @@ pub fn roundtrip_complex_test() {
 
   let assert Ok(encoded) = pack(value)
   let assert Ok(decoded) = unpack_exact(encoded)
-  decoded |> should.equal(value)
+  decoded |> expect.to_equal(value)
 }
 
 // ============================================================================
@@ -506,7 +517,7 @@ pub fn decode_all_nil_encodings_test() {
   list.each(cases, fn(test_case) {
     list.each(test_case.msgpack, fn(encoding) {
       let assert Ok(decoded) = unpack_exact(encoding)
-      decoded |> should.equal(Nil)
+      decoded |> expect.to_equal(Nil)
     })
   })
 }
@@ -524,7 +535,7 @@ pub fn decode_all_bool_encodings_test() {
 
     list.each(test_case.msgpack, fn(encoding) {
       let assert Ok(decoded) = unpack_exact(encoding)
-      decoded |> should.equal(expected)
+      decoded |> expect.to_equal(expected)
     })
   })
 }
@@ -539,7 +550,7 @@ pub fn timestamp_encode_32bit_test() {
   let value = timestamp.encode(ts)
   let assert Ok(data) = pack(value)
   // fixext4 (0xd6), type -1 (0xff), 4 bytes of zeros
-  data |> should.equal(<<0xd6, 0xff, 0x00, 0x00, 0x00, 0x00>>)
+  data |> expect.to_equal(<<0xd6, 0xff, 0x00, 0x00, 0x00, 0x00>>)
 }
 
 pub fn timestamp_encode_64bit_test() {
@@ -549,13 +560,14 @@ pub fn timestamp_encode_64bit_test() {
   let assert Ok(data) = pack(value)
   // fixext8 (0xd7), type -1 (0xff), 8 bytes
   let assert <<0xd7, 0xff, _:bits>> = data
+  Nil
 }
 
 pub fn timestamp_decode_32bit_test() {
   // Decode a 32-bit timestamp
   let assert Ok(value) = unpack_exact(<<0xd6, 0xff, 0x00, 0x00, 0x00, 0x01>>)
   let assert Ok(ts) = timestamp.decode(value)
-  ts |> should.equal(Timestamp(1, 0))
+  ts |> expect.to_equal(Timestamp(1, 0))
 }
 
 pub fn timestamp_roundtrip_test() {
@@ -565,35 +577,35 @@ pub fn timestamp_roundtrip_test() {
   let assert Ok(data) = pack(value)
   let assert Ok(decoded_value) = unpack_exact(data)
   let assert Ok(decoded_ts) = timestamp.decode(decoded_value)
-  decoded_ts |> should.equal(original)
+  decoded_ts |> expect.to_equal(original)
 }
 
 pub fn timestamp_from_unix_seconds_test() {
   let ts = timestamp.from_unix_seconds(1_234_567_890)
-  ts |> should.equal(Timestamp(1_234_567_890, 0))
+  ts |> expect.to_equal(Timestamp(1_234_567_890, 0))
 }
 
 pub fn timestamp_from_unix_millis_test() {
   let ts = timestamp.from_unix_millis(1_234_567_890_123)
-  ts.seconds |> should.equal(1_234_567_890)
-  ts.nanoseconds |> should.equal(123_000_000)
+  ts.seconds |> expect.to_equal(1_234_567_890)
+  ts.nanoseconds |> expect.to_equal(123_000_000)
 }
 
 pub fn timestamp_to_unix_millis_test() {
   let ts = Timestamp(1_234_567_890, 123_456_789)
   let millis = timestamp.to_unix_millis(ts)
-  millis |> should.equal(1_234_567_890_123)
+  millis |> expect.to_equal(1_234_567_890_123)
 }
 
 pub fn timestamp_is_timestamp_test() {
   // Extension with type -1 is a timestamp
-  timestamp.is_timestamp(Extension(-1, <<>>)) |> should.be_true
+  timestamp.is_timestamp(Extension(-1, <<>>)) |> expect.to_be_true
 
   // Other extensions are not timestamps
-  timestamp.is_timestamp(Extension(0, <<>>)) |> should.be_false
-  timestamp.is_timestamp(Extension(1, <<>>)) |> should.be_false
+  timestamp.is_timestamp(Extension(0, <<>>)) |> expect.to_be_false
+  timestamp.is_timestamp(Extension(1, <<>>)) |> expect.to_be_false
 
   // Other value types are not timestamps
-  timestamp.is_timestamp(Nil) |> should.be_false
-  timestamp.is_timestamp(Integer(0)) |> should.be_false
+  timestamp.is_timestamp(Nil) |> expect.to_be_false
+  timestamp.is_timestamp(Integer(0)) |> expect.to_be_false
 }


### PR DESCRIPTION
## Summary

- Replace `gleeunit` with `startest` testing framework in both root and codegen packages
- Convert all assertion calls from `should.*` to `expect.to_*` API
- Replace `should.fail()` with `panic as "unreachable"`
- Add explicit `Nil` returns to test functions ending with `expect.to_be_error()` or `let assert` patterns, since startest's test runner requires `fn() -> Nil` (unlike gleeunit which was lenient)
- Keeps existing flat `_test` function structure (startest also supports `describe`/`it` blocks for future use)

## Test plan

- [x] `gleam test` passes in root package (93 tests)
- [x] `gleam test` passes in codegen package (6 tests)