### PR TITLE
refactor(api): mark encode and decode modules as internal

### DIFF
--- a/.changes/unreleased/internal-modules-changed.yaml
+++ b/.changes/unreleased/internal-modules-changed.yaml
@@ -1,0 +1,2 @@
+kind: Changed
+body: Mark `encode` and `decode` modules as internal. Use `pack`, `unpack`, and `unpack_exact` from the main `msgpack_gleam` module instead.

--- a/gleam.toml
+++ b/gleam.toml
@@ -4,6 +4,7 @@ description = "A MessagePack implementation for Gleam"
 licences = ["MIT"]
 
 target = "erlang"
+internal_modules = ["msgpack_gleam/encode", "msgpack_gleam/decode"]
 
 [dependencies]
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"


### PR DESCRIPTION
## Summary

- Mark `msgpack_gleam/encode` and `msgpack_gleam/decode` as `internal_modules` in `gleam.toml`
- These are implementation details — consumers use `pack`/`unpack`/`unpack_exact` from the main module

## Test plan

- [x] `just ci` passes (315 tests)
- [ ] `gleam docs build` no longer shows encode/decode in public API docs

Closes #15