### PR TITLE
docs: clarify encoding contract and error type stability

### DIFF
--- a/.changes/unreleased/api-contracts-changed.yaml
+++ b/.changes/unreleased/api-contracts-changed.yaml
@@ -1,0 +1,2 @@
+kind: Changed
+body: Clarify canonical encoding contract (integers use smallest format; floats always use float64). Document stability guarantees for all error types.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A pure Gleam implementation of [MessagePack](https://msgpack.org/), an efficient
 ## Features
 
 - **Complete MessagePack specification support** - All data types including nil, bool, int, float, string, binary, array, map, and extension types
-- **Canonical encoding** - Always produces the smallest valid encoding
+- **Canonical encoding** - Integers use the smallest valid format; floats use float64 for full precision
 - **Built-in timestamp support** - Convenience API for MessagePack timestamp extension type
 - **Streaming decode** - Decode values from a byte stream with remaining bytes returned
 - **Comprehensive test suite** - Validated against [msgpack-test-suite](https://github.com/kawanet/msgpack-test-suite)

--- a/src/msgpack_gleam.gleam
+++ b/src/msgpack_gleam.gleam
@@ -56,8 +56,9 @@ import msgpack_gleam/value.{type Value}
 
 /// Encode a MessagePack Value to binary data.
 ///
-/// Returns the canonical (smallest) encoding for each value. This follows
-/// the MessagePack specification recommendation for deterministic encoding.
+/// Returns the canonical encoding for each value. Integers use the smallest
+/// format; floats always use float64 for full precision. This follows the
+/// MessagePack specification recommendation for deterministic encoding.
 ///
 /// ## Example
 ///

--- a/src/msgpack_gleam/codec.gleam
+++ b/src/msgpack_gleam/codec.gleam
@@ -64,7 +64,10 @@ pub opaque type Codec(a) {
   )
 }
 
-/// Errors that can occur during decoding.
+/// Errors that can occur during codec-level decoding.
+///
+/// This type is transparent for exhaustive pattern matching.
+/// New variants are only added in major version bumps.
 pub type CodecDecodeError {
   /// Expected a different type
   TypeMismatch(expected: String, got: String)

--- a/src/msgpack_gleam/encode.gleam
+++ b/src/msgpack_gleam/encode.gleam
@@ -6,7 +6,8 @@ import msgpack_gleam/error.{type EncodeError}
 import msgpack_gleam/value.{type Value}
 
 /// Encode a MessagePack Value to binary data.
-/// Returns the canonical (smallest) encoding for each value.
+/// Returns the canonical encoding for each value. Integers use the smallest
+/// format; floats always use float64 for full precision.
 pub fn encode(value: Value) -> Result(BitArray, EncodeError) {
   encode_value(value)
   |> result.map(bytes_tree.to_bit_array)

--- a/src/msgpack_gleam/error.gleam
+++ b/src/msgpack_gleam/error.gleam
@@ -1,6 +1,9 @@
 import gleam/int
 
 /// Errors that can occur during MessagePack encoding.
+///
+/// This type is transparent for exhaustive pattern matching.
+/// New variants are only added in major version bumps.
 pub type EncodeError {
   /// Integer is too large to be represented in MessagePack format
   IntegerTooLarge(Int)
@@ -19,6 +22,9 @@ pub type EncodeError {
 }
 
 /// Errors that can occur during MessagePack decoding.
+///
+/// This type is transparent for exhaustive pattern matching.
+/// New variants are only added in major version bumps.
 pub type DecodeError {
   /// Unexpected end of input
   UnexpectedEof

--- a/src/msgpack_gleam/timestamp.gleam
+++ b/src/msgpack_gleam/timestamp.gleam
@@ -14,6 +14,9 @@ import msgpack_gleam/value.{type Value, Extension}
 pub const timestamp_type_code: Int = -1
 
 /// Errors that can occur during timestamp operations.
+///
+/// This type is transparent for exhaustive pattern matching.
+/// New variants are only added in major version bumps.
 pub type TimestampError {
   /// Nanoseconds value is outside the valid range [0, 999_999_999]
   InvalidNanoseconds(Int)


### PR DESCRIPTION
## Summary

- Clarify that "canonical encoding" means integers use the smallest format while floats always use float64 for full precision (not "smallest valid encoding" across the board)
- Add stability annotations to all public error types (`EncodeError`, `DecodeError`, `CodecDecodeError`, `TimestampError`) documenting that new variants are only added in major version bumps
- Error types remain transparent (not opaque) — exhaustive pattern matching is idiomatic Gleam

## Test plan

- [x] `just ci` passes (315 tests, no behavior changes)
- [ ] Review generated docs to confirm annotations appear

Closes #16
Closes #17