### PR TITLE
docs(codegen): document msgpack_codegen as experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ case unpack_exact(data) {
 }
 ```
 
+## Code Generation (Experimental)
+
+The `codegen/` directory contains `msgpack_codegen`, an experimental code
+generator for creating codec definitions from Gleam types. It is a separate
+package and is **not** covered by msgpack_gleam's versioning or stability
+guarantees.
+
 ## Development
 
 ```sh

--- a/codegen/gleam.toml
+++ b/codegen/gleam.toml
@@ -1,6 +1,6 @@
 name = "msgpack_codegen"
 version = "0.1.0"
-description = "Code generator for msgpack_gleam codecs"
+description = "Experimental code generator for msgpack_gleam codecs"
 licences = ["MIT"]
 
 target = "erlang"


### PR DESCRIPTION
## Summary

- Add "Code Generation (Experimental)" section to README
- Update codegen/gleam.toml description to include "Experimental"
- Makes explicit that `msgpack_codegen` is not covered by msgpack_gleam's versioning or stability guarantees

## Test plan

- [x] `just ci` passes (315 tests, no code changes)

Closes #19